### PR TITLE
feat(p4): implement F4 auto-icons and F6 organization workflows

### DIFF
--- a/e2e/api-mock.ts
+++ b/e2e/api-mock.ts
@@ -364,6 +364,18 @@ export async function mockRaindropApi(page: Page): Promise<void> {
       return route.fulfill({ json: { result: true, user: store.user } })
     }
 
+    // PUT /user
+    if (method === 'PUT' && path === '/user') {
+      const body = JSON.parse(
+        (await route.request().postData()) ?? '{}',
+      ) as Record<string, unknown>
+      store.user = {
+        ...store.user,
+        ...body,
+      }
+      return route.fulfill({ json: { result: true, user: store.user } })
+    }
+
     // GET /tags (with or without collectionId)
     if (method === 'GET' && /^\/tags(\/(-?\d+))?$/.test(path)) {
       return route.fulfill({ json: { result: true, items: store.tags } })
@@ -391,6 +403,26 @@ export async function mockRaindropApi(page: Page): Promise<void> {
         json: {
           result: true,
           item: { collections: [{ $id: 100 }], tags: ['suggested-tag'] },
+        },
+      })
+    }
+
+    // GET /raindrop/suggest?url=...
+    if (method === 'GET' && path === '/raindrop/suggest') {
+      const targetUrl = url.searchParams.get('url') ?? ''
+      let domain = ''
+      try {
+        domain = new URL(targetUrl).hostname
+      } catch {
+        /* ignore invalid URL */
+      }
+
+      return route.fulfill({
+        json: {
+          result: true,
+          item: {
+            meta: domain ? { icon: `https://${domain}/favicon.ico` } : {},
+          },
         },
       })
     }

--- a/e2e/specs/crud.spec.ts
+++ b/e2e/specs/crud.spec.ts
@@ -124,6 +124,146 @@ test.describe('Add Bookmark Dialog', () => {
   })
 })
 
+test.describe('P4 Auto Icon Assignment (F4)', () => {
+  // @spec:F4.1 - New bookmarks auto-fetch icon from suggest API
+  test('auto-fetches icon from suggest API in add bookmark dialog', async ({
+    page,
+  }) => {
+    await expect(
+      page.locator('[data-slot="breadcrumb-page"]', {
+        hasText: 'All Bookmarks',
+      }),
+    ).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await page
+      .getByRole('button', { name: /Add Bookmark|^Add$/ })
+      .first()
+      .click()
+    await expect(
+      page.getByRole('heading', { name: 'Add Bookmark' }),
+    ).toBeVisible()
+
+    await page.getByLabel('URL').fill('https://react.dev')
+    const preview = page.getByTestId('bookmark-favicon-preview')
+    await expect(preview).toBeAttached({ timeout: 10_000 })
+    await expect(preview).toHaveAttribute('src', /react\.dev\/favicon\.ico/)
+  })
+
+  // @spec:F4.2 - Fallback to Google Favicon API when suggest returns no icon
+  test('falls back to Google favicon when suggest icon is unavailable', async ({
+    page,
+  }) => {
+    await page.route(
+      '**/api.raindrop.io/rest/v1/raindrop/suggest?*',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            result: true,
+            item: { meta: {} },
+          }),
+        })
+      },
+    )
+
+    await expect(
+      page.locator('[data-slot="breadcrumb-page"]', {
+        hasText: 'All Bookmarks',
+      }),
+    ).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await page
+      .getByRole('button', { name: /Add Bookmark|^Add$/ })
+      .first()
+      .click()
+    await page.getByLabel('URL').fill('https://react.dev')
+
+    const preview = page.getByTestId('bookmark-favicon-preview')
+    await expect(preview).toBeAttached({ timeout: 10_000 })
+    await expect(preview).toHaveAttribute(
+      'src',
+      /google\.com\/s2\/favicons\?domain=react\.dev&sz=64/,
+    )
+  })
+
+  // @spec:F4.3 - Display domain first letter when no icon available
+  test('renders domain initial fallback when favicon image cannot load', async ({
+    page,
+  }) => {
+    await page.route('**/www.google.com/s2/favicons**', async (route) => {
+      await route.fulfill({ status: 404, body: '' })
+    })
+
+    await expect(
+      page.locator('[data-slot="breadcrumb-page"]', {
+        hasText: 'All Bookmarks',
+      }),
+    ).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await expect
+      .poll(async () => {
+        return page
+          .getByTestId('favicon-1')
+          .evaluate((element) => element.tagName)
+      })
+      .toBe('DIV')
+
+    await expect
+      .poll(async () => {
+        return page
+          .getByTestId('favicon-1')
+          .evaluate((element) => (element.textContent ?? '').trim())
+      })
+      .toBe('R')
+  })
+
+  // @spec:F4.4 - Background icon resolution does not block UI
+  test('keeps add bookmark form interactive during icon resolution', async ({
+    page,
+  }) => {
+    await page.route(
+      '**/api.raindrop.io/rest/v1/raindrop/suggest?*',
+      async (route) => {
+        await page.waitForTimeout(1_000)
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            result: true,
+            item: { meta: { icon: 'https://react.dev/favicon.ico' } },
+          }),
+        })
+      },
+    )
+
+    await expect(
+      page.locator('[data-slot="breadcrumb-page"]', {
+        hasText: 'All Bookmarks',
+      }),
+    ).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await page
+      .getByRole('button', { name: /Add Bookmark|^Add$/ })
+      .first()
+      .click()
+    await expect(
+      page.getByRole('heading', { name: 'Add Bookmark' }),
+    ).toBeVisible()
+
+    await page.getByLabel('URL').fill('https://react.dev')
+
+    await page.getByLabel('Title').fill('Manual Title')
+    await expect(page.getByLabel('Title')).toHaveValue('Manual Title')
+  })
+})
+
 test.describe('Bookmark List Rendering', () => {
   // @spec:API.1 - GET /raindrops/{collectionId} (browse bookmarks)
   test('should render mocked bookmarks in list view', async ({ page }) => {

--- a/e2e/specs/dnd.spec.ts
+++ b/e2e/specs/dnd.spec.ts
@@ -170,7 +170,7 @@ test.describe('P4 Organization - DnD and Context Menu (F6)', () => {
     // Change color
     await openCollectionContextMenu(page, '100')
     await page.getByRole('menuitem', { name: 'Change Color' }).hover()
-    await page.getByRole('menuitem', { name: '#ef4444' }).last().click()
+    await page.getByRole('menuitem', { name: 'Red' }).last().click()
     await expect(page.getByTestId('collection-color-100')).toBeVisible()
 
     // Delete

--- a/e2e/specs/dnd.spec.ts
+++ b/e2e/specs/dnd.spec.ts
@@ -1,0 +1,217 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { expect, test } from '../electron'
+
+/**
+ * Wait until the app reaches a stable, authenticated state.
+ * @param page - Playwright page
+ */
+async function waitForSidebarReady(page: Page) {
+  await expect(
+    page.locator('[data-slot="breadcrumb-page"]', {
+      hasText: 'All Bookmarks',
+    }),
+  ).toBeVisible({ timeout: 10_000 })
+}
+
+/**
+ * Get ordered root collection IDs visible in one sidebar group.
+ * @param page - Playwright page
+ * @param groupId - Group test identifier suffix (e.g. "group-0")
+ * @returns Ordered list of collection IDs
+ */
+async function getGroupRootCollectionIds(
+  page: Page,
+  groupId: string,
+): Promise<string[]> {
+  const ids = await page
+    .getByTestId(`sidebar-group-${groupId}`)
+    .locator('[data-testid^="sidebar-collection-"]')
+    .evaluateAll((elements) => {
+      return elements
+        .map((element) => element.getAttribute('data-testid') ?? '')
+        .map((value) => value.replace('sidebar-collection-', ''))
+        .filter(Boolean)
+    })
+  return ids
+}
+
+/**
+ * Perform manual drag-and-drop (with double hover for dragover reliability).
+ * @param page - Playwright page
+ * @param sourceCollectionId - Source collection ID
+ * @param target - Target locator
+ */
+async function dragCollectionToTarget(
+  page: Page,
+  sourceCollectionId: string,
+  target: Locator,
+) {
+  const source = page.getByTestId(`sidebar-collection-${sourceCollectionId}`)
+  await source.hover()
+  await page.mouse.down()
+  await target.hover()
+  await target.hover()
+  await page.mouse.up()
+}
+
+/**
+ * Open context menu for one collection row.
+ * @param page - Playwright page
+ * @param collectionId - Collection ID
+ */
+async function openCollectionContextMenu(page: Page, collectionId: string) {
+  await page
+    .getByTestId(`sidebar-collection-${collectionId}`)
+    .click({ button: 'right' })
+}
+
+test.describe('P4 Organization - DnD and Context Menu (F6)', () => {
+  // @spec:F6.1 - Drag collection between groups updates API
+  // @spec:F6.5 - Drag preview shows collection icon + name
+  // @spec:F6.6 - Drop indicator shows insertion point
+  test('moves collection across groups with drag preview and drop indicator', async ({
+    page,
+  }) => {
+    await waitForSidebarReady(page)
+
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-0'))
+      .toContain('100')
+
+    const source = page.getByTestId('sidebar-collection-100')
+    const targetGroup = page.getByTestId('sidebar-group-group-1')
+
+    await source.hover()
+    await page.mouse.down()
+    await targetGroup.hover()
+    await targetGroup.hover()
+
+    await expect(page.getByTestId('drag-preview')).toBeVisible()
+    await expect(
+      page.locator('[data-testid^="drop-indicator-"]').first(),
+    ).toBeVisible()
+
+    await page.mouse.up()
+
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-1'))
+      .toContain('100')
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-0'))
+      .not.toContain('100')
+  })
+
+  // @spec:F6.2 - Reorder within group works and persists
+  test('reorders collections within a group and keeps order after reload', async ({
+    page,
+  }) => {
+    await waitForSidebarReady(page)
+
+    const before = await getGroupRootCollectionIds(page, 'group-0')
+    expect(before).toEqual(['100', '102'])
+
+    await dragCollectionToTarget(
+      page,
+      '102',
+      page.getByTestId('sidebar-collection-100'),
+    )
+
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-0'))
+      .toEqual(['102', '100'])
+
+    await page.reload()
+    await waitForSidebarReady(page)
+
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-0'))
+      .toEqual(['102', '100'])
+  })
+
+  // @spec:F6.3 - Double-click enables inline rename
+  test('supports inline rename on double-click', async ({ page }) => {
+    await waitForSidebarReady(page)
+
+    const row = page.getByTestId('sidebar-collection-100')
+    await row.dblclick()
+    const inlineInput = row.locator('input')
+    await expect(inlineInput).toBeVisible()
+
+    await inlineInput.fill('Renamed Collection')
+    await inlineInput.press('Enter')
+
+    await expect(row.getByText('Renamed Collection')).toBeVisible()
+  })
+
+  // @spec:F6.4 - Right-click context menu with all options
+  test('supports context menu rename, move, color, and delete actions', async ({
+    page,
+  }) => {
+    await waitForSidebarReady(page)
+
+    // Rename
+    await openCollectionContextMenu(page, '100')
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+    const renamedRow = page.getByTestId('sidebar-collection-100')
+    const renameInput = renamedRow.locator('input')
+    await renameInput.fill('Context Renamed')
+    await renameInput.press('Enter')
+    await expect(renamedRow.getByText('Context Renamed')).toBeVisible()
+
+    // Move to Group
+    await openCollectionContextMenu(page, '100')
+    await page.getByRole('menuitem', { name: 'Move to Group' }).hover()
+    await page.getByRole('menuitem', { name: 'Creative' }).last().click()
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-1'))
+      .toContain('100')
+
+    // Change color
+    await openCollectionContextMenu(page, '100')
+    await page.getByRole('menuitem', { name: 'Change Color' }).hover()
+    await page.getByRole('menuitem', { name: '#ef4444' }).last().click()
+    await expect(page.getByTestId('collection-color-100')).toBeVisible()
+
+    // Delete
+    await openCollectionContextMenu(page, '100')
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await expect(page.getByTestId('sidebar-collection-100')).not.toBeVisible()
+  })
+
+  // @spec:F6.7 - Optimistic updates: UI updates immediately, reverts on error
+  test('rolls back optimistic group move when persistence fails', async ({
+    page,
+  }) => {
+    await waitForSidebarReady(page)
+
+    let failedOnce = false
+    await page.route('**/api.raindrop.io/rest/v1/user', async (route) => {
+      if (route.request().method() === 'PUT' && !failedOnce) {
+        failedOnce = true
+        await page.waitForTimeout(600)
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ result: false }),
+        })
+        return
+      }
+      await route.fallback()
+    })
+
+    await openCollectionContextMenu(page, '100')
+    await page.getByRole('menuitem', { name: 'Move to Group' }).hover()
+    await page.getByRole('menuitem', { name: 'Creative' }).last().click()
+
+    // Optimistic move first.
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-1'))
+      .toContain('100')
+
+    // Then rollback after failed mutation.
+    await expect
+      .poll(async () => getGroupRootCollectionIds(page, 'group-0'))
+      .toContain('100')
+  })
+})

--- a/e2e/specs/dnd.spec.ts
+++ b/e2e/specs/dnd.spec.ts
@@ -7,11 +7,12 @@ import { expect, test } from '../electron'
  * @param page - Playwright page
  */
 async function waitForSidebarReady(page: Page) {
-  await expect(
-    page.locator('[data-slot="breadcrumb-page"]', {
-      hasText: 'All Bookmarks',
-    }),
-  ).toBeVisible({ timeout: 10_000 })
+  const allBookmarksButton = page
+    .getByRole('button', { name: 'All Bookmarks' })
+    .first()
+  await expect(allBookmarksButton).toBeVisible({ timeout: 10_000 })
+  await allBookmarksButton.click({ force: true })
+  await expect(page.getByRole('button', { name: 'Unsorted' })).toBeVisible()
 }
 
 /**

--- a/e2e/specs/search.spec.ts
+++ b/e2e/specs/search.spec.ts
@@ -47,9 +47,16 @@ async function resetToAllBookmarks(page: Page) {
     await page.waitForTimeout(100)
   }
 
-  const allBookmarksControl = page.getByText('All Bookmarks').first()
+  const allBookmarksControl = page
+    .getByRole('button', { name: 'All Bookmarks' })
+    .first()
   await expect(allBookmarksControl).toBeVisible({ timeout: 10_000 })
   await allBookmarksControl.click({ force: true })
+  await expect(
+    page.locator('[data-slot="breadcrumb-page"]', {
+      hasText: 'All Bookmarks',
+    }),
+  ).toBeVisible({ timeout: 10_000 })
 
   const mainSearchInput = page.getByPlaceholder('Search bookmarks... (Cmd+K)')
   await expect(mainSearchInput).toBeVisible()
@@ -155,6 +162,16 @@ test.describe('P3 Search - Field-Specific Search (F2)', () => {
     const commandDialog = page.getByRole('dialog')
     const commandInput = page.getByPlaceholder(/⌘K/)
     await expect(commandInput).toBeVisible()
+
+    const searchEverywhereButton = commandDialog.getByRole('button', {
+      name: 'Search everywhere',
+    })
+    if (
+      (await searchEverywhereButton.count()) > 0 &&
+      (await searchEverywhereButton.first().isVisible())
+    ) {
+      await searchEverywhereButton.first().click()
+    }
 
     // URL scope
     await commandDialog.getByRole('button', { name: 'URL Only' }).click()

--- a/src/components/main-app.tsx
+++ b/src/components/main-app.tsx
@@ -19,6 +19,7 @@ import { mapSortOptionToApi } from '@/lib/api-mappers'
 import { buildSearchQuery } from '@/lib/search'
 import type {
   Collection,
+  Group,
   Raindrop,
   SearchMode,
   SearchScope,
@@ -133,6 +134,9 @@ export const MainApp = React.memo(function MainApp() {
     deleteCollection,
     merge,
     emptyTrash,
+    updateUserGroups,
+    renameCollection,
+    recolorCollection,
   } = useCollectionsCrud()
 
   // Bridge: string[] (Redux) → Set<string> (MainContent expects Set)
@@ -281,19 +285,46 @@ export const MainApp = React.memo(function MainApp() {
     [saveCollection, updateCollection, dispatch],
   )
 
-  const handleEditCollection = useCallback(
-    (collection: Collection) => {
-      setEditingCollection(collection)
-      dispatch(openCollectionDialog())
-    },
-    [dispatch],
-  )
-
   const handleDeleteCollection = useCallback(
     async (collectionId: string) => {
       await deleteCollection(collectionId)
     },
     [deleteCollection],
+  )
+
+  /**
+   * Persist sidebar group ordering and membership updates.
+   * @param nextGroups - Updated group structure from sidebar interactions
+   */
+  const handlePersistGroups = useCallback(
+    async (nextGroups: Group[]) => {
+      await updateUserGroups(nextGroups)
+    },
+    [updateUserGroups],
+  )
+
+  /**
+   * Rename a collection from inline sidebar editing.
+   * @param collectionId - Collection ID
+   * @param title - New collection title
+   */
+  const handleRenameCollection = useCallback(
+    async (collectionId: string, title: string) => {
+      await renameCollection(collectionId, title)
+    },
+    [renameCollection],
+  )
+
+  /**
+   * Update collection color from sidebar context menu.
+   * @param collectionId - Collection ID
+   * @param color - Selected color
+   */
+  const handleChangeCollectionColor = useCallback(
+    async (collectionId: string, color: string) => {
+      await recolorCollection(collectionId, color)
+    },
+    [recolorCollection],
   )
 
   const handleEmptyTrash = useCallback(async () => {
@@ -458,10 +489,12 @@ export const MainApp = React.memo(function MainApp() {
           onAddCollection={handleAddCollection}
           onAddGroup={handleAddGroup}
           onManageTags={handleManageTags}
-          onEditCollection={handleEditCollection}
           onDeleteCollection={handleDeleteCollection}
           onEmptyTrash={handleEmptyTrash}
           onMergeCollections={handleOpenMerge}
+          onPersistGroups={handlePersistGroups}
+          onRenameCollection={handleRenameCollection}
+          onChangeCollectionColor={handleChangeCollectionColor}
         />
 
         <SidebarInset className="min-w-0 flex-1">

--- a/src/components/raindrop/add-bookmark-dialog.tsx
+++ b/src/components/raindrop/add-bookmark-dialog.tsx
@@ -139,10 +139,16 @@ function useBookmarkFormReset(
  * @param url - The URL value to parse
  * @param parseUrl - URL parsing callback
  */
-function useDebouncedUrlParsing(url: string, parseUrl: (url: string) => void) {
+function useDebouncedUrlParsing(
+  url: string,
+  parseUrl: (url: string) => Promise<void>,
+) {
   useEffect(() => {
     if (!url) return
-    const debounce = setTimeout(() => parseUrl(url), URL_PARSE_DEBOUNCE_MS)
+    const debounce = setTimeout(
+      () => void parseUrl(url).catch(() => undefined),
+      URL_PARSE_DEBOUNCE_MS,
+    )
     return () => clearTimeout(debounce)
   }, [url, parseUrl])
 }

--- a/src/components/raindrop/add-bookmark-dialog.tsx
+++ b/src/components/raindrop/add-bookmark-dialog.tsx
@@ -150,17 +150,31 @@ function useDebouncedUrlParsing(url: string, parseUrl: (url: string) => void) {
 /**
  * Clear parsed favicon when auto icon mode is disabled.
  * @param autoIcon - Auto icon flag
+ * @param url - Current URL input value
  * @param setParsedFavicon - Parsed favicon setter
+ * @param parseUrl - Existing parse-and-resolve callback
  */
 function useParsedFaviconReset(
   autoIcon: boolean,
+  url: string,
   setParsedFavicon: React.Dispatch<React.SetStateAction<string>>,
+  parseUrl: (url: string) => Promise<void>,
 ) {
+  const previousAutoIconRef = useRef(autoIcon)
+
   useEffect(() => {
+    const wasAutoIcon = previousAutoIconRef.current
+    previousAutoIconRef.current = autoIcon
+
     if (!autoIcon) {
       setParsedFavicon('')
+      return
     }
-  }, [autoIcon, setParsedFavicon])
+
+    if (!wasAutoIcon && autoIcon && url) {
+      void parseUrl(url)
+    }
+  }, [autoIcon, parseUrl, setParsedFavicon, url])
 }
 
 /**
@@ -233,8 +247,6 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
     setAutoIcon,
   })
 
-  useParsedFaviconReset(autoIcon, setParsedFavicon)
-
   // Auto-parse URL metadata and icon.
   const parseUrl = useCallback(
     async (urlValue: string) => {
@@ -288,6 +300,8 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
     },
     [autoIcon, setValue, watch],
   )
+
+  useParsedFaviconReset(autoIcon, url, setParsedFavicon, parseUrl)
 
   useDebouncedUrlParsing(url, parseUrl)
 

--- a/src/components/raindrop/add-bookmark-dialog.tsx
+++ b/src/components/raindrop/add-bookmark-dialog.tsx
@@ -13,7 +13,7 @@ import {
   Plus,
   Sparkles,
 } from 'lucide-react'
-import React, { useEffect, useState, useCallback, useMemo } from 'react'
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -45,7 +45,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import type { Group, ContentType } from '@/lib/types'
-import { extractDomain, getFaviconUrl } from '@/utils/favicon'
+import { extractDomain, resolveIcon } from '@/utils/favicon'
 
 const bookmarkSchema = z.object({
   url: z.string().url('Please enter a valid URL'),
@@ -58,6 +58,11 @@ const bookmarkSchema = z.object({
 })
 
 type BookmarkFormValues = z.infer<typeof bookmarkSchema>
+
+/**
+ * Debounce interval for URL parsing and icon resolution.
+ */
+const URL_PARSE_DEBOUNCE_MS = 500
 
 /**
  * Type icon mapping for the content type selector.
@@ -137,9 +142,25 @@ function useBookmarkFormReset(
 function useDebouncedUrlParsing(url: string, parseUrl: (url: string) => void) {
   useEffect(() => {
     if (!url) return
-    const debounce = setTimeout(() => parseUrl(url), 500)
+    const debounce = setTimeout(() => parseUrl(url), URL_PARSE_DEBOUNCE_MS)
     return () => clearTimeout(debounce)
   }, [url, parseUrl])
+}
+
+/**
+ * Clear parsed favicon when auto icon mode is disabled.
+ * @param autoIcon - Auto icon flag
+ * @param setParsedFavicon - Parsed favicon setter
+ */
+function useParsedFaviconReset(
+  autoIcon: boolean,
+  setParsedFavicon: React.Dispatch<React.SetStateAction<string>>,
+) {
+  useEffect(() => {
+    if (!autoIcon) {
+      setParsedFavicon('')
+    }
+  }, [autoIcon, setParsedFavicon])
 }
 
 /**
@@ -178,6 +199,7 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
   const [parsedFavicon, setParsedFavicon] = useState('')
   const [isNotesOpen, setIsNotesOpen] = useState(false)
   const [autoIcon, setAutoIcon] = useState(true)
+  const parseRequestIdRef = useRef(0)
 
   const {
     register,
@@ -211,9 +233,11 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
     setAutoIcon,
   })
 
-  // Auto-parse URL (simulated - in real app would call Raindrop API)
+  useParsedFaviconReset(autoIcon, setParsedFavicon)
+
+  // Auto-parse URL metadata and icon.
   const parseUrl = useCallback(
-    (urlValue: string) => {
+    async (urlValue: string) => {
       if (!urlValue) return
       try {
         new URL(urlValue)
@@ -221,44 +245,46 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
         return
       }
 
+      const requestId = parseRequestIdRef.current + 1
+      parseRequestIdRef.current = requestId
       setIsParsing(true)
       const domain = extractDomain(urlValue)
 
-      // Simulate URL parsing delay
-      const timeout = setTimeout(() => {
-        if (autoIcon && domain) {
-          setParsedFavicon(getFaviconUrl(domain))
+      // Auto-detect type from URL.
+      if (urlValue.match(/youtube\.com|vimeo\.com|dailymotion\.com|\.mp4$/i)) {
+        setValue('type', 'video')
+      } else if (urlValue.match(/\.(png|jpg|jpeg|gif|webp|svg)$/i)) {
+        setValue('type', 'image')
+      } else if (urlValue.match(/\.(pdf|doc|docx|xls|xlsx|ppt|pptx)$/i)) {
+        setValue('type', 'document')
+      } else if (urlValue.match(/\.(mp3|wav|ogg|flac|aac)$/i)) {
+        setValue('type', 'audio')
+      } else if (
+        urlValue.match(
+          /medium\.com|dev\.to|hashnode\.dev|substack\.com|blog\./i,
+        )
+      ) {
+        setValue('type', 'article')
+      }
+
+      // Auto-fill title from domain if empty.
+      const currentTitle = watch('title')
+      if (!currentTitle) {
+        setValue('title', domain ? `${domain} - Untitled` : '')
+      }
+
+      try {
+        if (autoIcon) {
+          const resolvedIcon = await resolveIcon(urlValue)
+          if (parseRequestIdRef.current === requestId) {
+            setParsedFavicon(resolvedIcon ?? '')
+          }
         }
-
-        // Auto-detect type from URL
-        if (
-          urlValue.match(/youtube\.com|vimeo\.com|dailymotion\.com|\.mp4$/i)
-        ) {
-          setValue('type', 'video')
-        } else if (urlValue.match(/\.(png|jpg|jpeg|gif|webp|svg)$/i)) {
-          setValue('type', 'image')
-        } else if (urlValue.match(/\.(pdf|doc|docx|xls|xlsx|ppt|pptx)$/i)) {
-          setValue('type', 'document')
-        } else if (urlValue.match(/\.(mp3|wav|ogg|flac|aac)$/i)) {
-          setValue('type', 'audio')
-        } else if (
-          urlValue.match(
-            /medium\.com|dev\.to|hashnode\.dev|substack\.com|blog\./i,
-          )
-        ) {
-          setValue('type', 'article')
+      } finally {
+        if (parseRequestIdRef.current === requestId) {
+          setIsParsing(false)
         }
-
-        // Auto-fill title from domain if empty
-        const currentTitle = watch('title')
-        if (!currentTitle) {
-          setValue('title', domain ? `${domain} - Untitled` : '')
-        }
-
-        setIsParsing(false)
-      }, 500)
-
-      return () => clearTimeout(timeout)
+      }
     },
     [autoIcon, setValue, watch],
   )
@@ -359,6 +385,7 @@ const AddBookmarkDialog = React.memo(function AddBookmarkDialog({
               <div className="flex items-center gap-2">
                 {parsedFavicon && (
                   <img
+                    data-testid="bookmark-favicon-preview"
                     src={parsedFavicon}
                     alt=""
                     className="h-5 w-5 shrink-0 rounded-sm"

--- a/src/components/raindrop/drag-preview.tsx
+++ b/src/components/raindrop/drag-preview.tsx
@@ -1,17 +1,40 @@
+import React from 'react'
+
+import type { Collection } from '@/lib/types'
+
 /**
- * Placeholder component for drag preview overlay.
- * Original implementation used react-dnd's DragLayer.
- *
- * // TODO: @dnd-kit migration
- * This component will be reimplemented with @dnd-kit's DragOverlay
- * to show a ghost card following the cursor during drag operations.
- *
- * @example
- *   <DragPreview />
+ * Props for the drag overlay preview.
  */
-export function DragPreview() {
-  // TODO: @dnd-kit migration
-  // Will use DragOverlay from @dnd-kit/core to render
-  // a floating preview of the dragged item(s).
-  return null
+interface DragPreviewProps {
+  /** Active collection being dragged. */
+  collection?: Collection
 }
+
+/**
+ * Floating drag preview shown by `DragOverlay`.
+ * @param collection - Currently dragged root collection
+ * @returns Overlay content or null when no active drag exists
+ * @example
+ *   <DragPreview collection={activeCollection} />
+ */
+const DragPreview = React.memo(function DragPreview({
+  collection,
+}: DragPreviewProps) {
+  if (!collection) return null
+
+  return (
+    <div
+      data-testid="drag-preview"
+      className="bg-popover text-popover-foreground flex min-w-44 items-center gap-2 rounded-md border px-3 py-2 shadow-lg"
+    >
+      <div
+        className="h-3 w-3 flex-shrink-0 rounded-sm"
+        style={{ backgroundColor: collection.color || '#8b5cf6' }}
+      />
+      <span className="truncate text-sm font-medium">{collection.name}</span>
+    </div>
+  )
+})
+
+export { DragPreview }
+export default DragPreview

--- a/src/components/raindrop/drop-indicator.tsx
+++ b/src/components/raindrop/drop-indicator.tsx
@@ -1,22 +1,50 @@
+import React from 'react'
+
+import { cn } from '@/lib/utils'
+
 /**
- * Placeholder component for drop zone indicator lines.
- * Original implementation used react-dnd's useDrop hook.
- *
- * // TODO: @dnd-kit migration
- * This component will be reimplemented with @dnd-kit to show
- * insertion lines and highlight valid drop zones during drag operations.
- *
- * @example
- *   <DropIndicator position="after" isActive={false} />
+ * Props for the drop indicator line.
  */
-export function DropIndicator(_props: {
-  /** Position relative to the sibling element */
+interface DropIndicatorProps {
+  /** Position relative to a sibling row. */
   position?: 'before' | 'after' | 'inside'
-  /** Whether the indicator is currently active (item hovering over) */
+  /** Whether the indicator is active. */
   isActive?: boolean
-}) {
-  // TODO: @dnd-kit migration
-  // Will render a thin primary-color line with dot endpoints
-  // at the insertion point when a draggable item hovers nearby.
-  return null
+  /** Optional test selector for E2E. */
+  'data-testid'?: string
 }
+
+/**
+ * Visual insertion marker shown while dragging collections.
+ * @param position - Drop position around the row
+ * @param isActive - Indicator visibility flag
+ * @returns Indicator line when active, otherwise null
+ * @example
+ *   <DropIndicator position="before" isActive />
+ */
+const DropIndicator = React.memo(function DropIndicator({
+  position = 'before',
+  isActive = false,
+  'data-testid': dataTestId,
+}: DropIndicatorProps) {
+  if (!isActive) return null
+
+  return (
+    <div
+      data-testid={dataTestId}
+      className={cn(
+        'pointer-events-none relative h-2',
+        position === 'before' && '-mt-1 mb-0.5',
+        position === 'after' && 'mt-0.5 mb-0',
+        position === 'inside' && 'my-0.5',
+      )}
+      aria-hidden
+    >
+      <span className="bg-primary absolute top-1/2 right-2 left-5 h-0.5 -translate-y-1/2 rounded-full" />
+      <span className="bg-primary absolute top-1/2 left-3 h-1.5 w-1.5 -translate-y-1/2 rounded-full" />
+    </div>
+  )
+})
+
+export { DropIndicator }
+export default DropIndicator

--- a/src/components/raindrop/favicon-icon.tsx
+++ b/src/components/raindrop/favicon-icon.tsx
@@ -22,6 +22,8 @@ interface FaviconIconProps {
   size?: number
   /** Additional CSS classes */
   className?: string
+  /** Optional selector for tests */
+  'data-testid'?: string
 }
 
 /**
@@ -55,6 +57,7 @@ const FaviconIcon = React.memo(function FaviconIcon({
   type = 'link',
   size = 32,
   className,
+  'data-testid': dataTestId,
 }: FaviconIconProps) {
   const [imgError, setImgError] = useState(false)
   const domain = extractDomain(url)
@@ -67,53 +70,56 @@ const FaviconIcon = React.memo(function FaviconIcon({
     [size],
   )
 
-  if (!domain || imgError) {
-    if (domain && !imgError) {
-      return (
-        <div
-          className={cn(
-            'flex flex-shrink-0 items-center justify-center rounded-sm',
-            className,
-          )}
-          style={{
-            width: size,
-            height: size,
-            backgroundColor: color,
-          }}
-        >
-          <span
-            className="font-semibold text-white"
-            style={{ fontSize: size * 0.5 }}
-          >
-            {initial}
-          </span>
-        </div>
-      )
-    }
+  if (domain && !imgError) {
+    return (
+      <img
+        data-testid={dataTestId}
+        src={faviconUrl}
+        alt={`${domain} favicon`}
+        width={size}
+        height={size}
+        className={cn('flex-shrink-0 rounded-sm object-cover', className)}
+        onError={() => setImgError(true)}
+        loading="lazy"
+      />
+    )
+  }
 
+  if (domain) {
     return (
       <div
+        data-testid={dataTestId}
         className={cn(
-          'bg-muted flex flex-shrink-0 items-center justify-center rounded-sm',
+          'flex flex-shrink-0 items-center justify-center rounded-sm',
           className,
         )}
-        style={{ width: size, height: size }}
+        style={{
+          width: size,
+          height: size,
+          backgroundColor: color,
+        }}
       >
-        <TypeIcon className="text-muted-foreground" style={typeIconStyle} />
+        <span
+          className="font-semibold text-white"
+          style={{ fontSize: size * 0.5 }}
+        >
+          {initial}
+        </span>
       </div>
     )
   }
 
   return (
-    <img
-      src={faviconUrl}
-      alt={`${domain} favicon`}
-      width={size}
-      height={size}
-      className={cn('flex-shrink-0 rounded-sm object-cover', className)}
-      onError={() => setImgError(true)}
-      loading="lazy"
-    />
+    <div
+      data-testid={dataTestId}
+      className={cn(
+        'bg-muted flex flex-shrink-0 items-center justify-center rounded-sm',
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <TypeIcon className="text-muted-foreground" style={typeIconStyle} />
+    </div>
   )
 })
 export { FaviconIcon }

--- a/src/components/raindrop/left-sidebar.tsx
+++ b/src/components/raindrop/left-sidebar.tsx
@@ -420,6 +420,7 @@ const CollectionRow = React.memo(function CollectionRow({
 
             {isEditing ? (
               <input
+                aria-label={`Rename collection ${collection.name}`}
                 value={editingName}
                 onChange={(event) => onEditingNameChange(event.target.value)}
                 onClick={stopPropagation}

--- a/src/components/raindrop/left-sidebar.tsx
+++ b/src/components/raindrop/left-sidebar.tsx
@@ -37,6 +37,7 @@ import {
 import React, {
   useCallback,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
 } from 'react'
@@ -104,14 +105,14 @@ import { cn } from '@/lib/utils'
  * Preset colors shown in collection context-menu.
  */
 const COLLECTION_COLOR_OPTIONS = [
-  '#ef4444',
-  '#f97316',
-  '#eab308',
-  '#22c55e',
-  '#06b6d4',
-  '#3b82f6',
-  '#8b5cf6',
-  '#ec4899',
+  { value: '#ef4444', label: 'Red' },
+  { value: '#f97316', label: 'Orange' },
+  { value: '#eab308', label: 'Yellow' },
+  { value: '#22c55e', label: 'Green' },
+  { value: '#06b6d4', label: 'Cyan' },
+  { value: '#3b82f6', label: 'Blue' },
+  { value: '#8b5cf6', label: 'Purple' },
+  { value: '#ec4899', label: 'Pink' },
 ] as const
 
 /**
@@ -365,11 +366,11 @@ const CollectionRow = React.memo(function CollectionRow({
 
   const colorHandlers = useMemo(() => {
     return new Map(
-      COLLECTION_COLOR_OPTIONS.map((color) => {
+      COLLECTION_COLOR_OPTIONS.map(({ value }) => {
         const handler = () => {
-          void onChangeCollectionColor(collection.id, color)
+          void onChangeCollectionColor(collection.id, value)
         }
-        return [color, handler]
+        return [value, handler]
       }),
     )
   }, [collection.id, onChangeCollectionColor])
@@ -483,12 +484,15 @@ const CollectionRow = React.memo(function CollectionRow({
           <ContextMenuSubTrigger>Change Color</ContextMenuSubTrigger>
           <ContextMenuSubContent className="w-40">
             {COLLECTION_COLOR_OPTIONS.map((color) => (
-              <ContextMenuItem key={color} onClick={colorHandlers.get(color)}>
+              <ContextMenuItem
+                key={color.value}
+                onClick={colorHandlers.get(color.value)}
+              >
                 <span
                   className="mr-2 inline-block h-3 w-3 rounded-sm border"
-                  style={{ backgroundColor: color }}
+                  style={{ backgroundColor: color.value }}
                 />
-                {color}
+                {color.label}
               </ContextMenuItem>
             ))}
           </ContextMenuSubContent>
@@ -863,6 +867,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
     groupId: string
     index: number
   } | null>(null)
+  const inlineRenameCancelledRef = useRef(false)
 
   const displayedGroups = useMemo(() => {
     if (!optimisticGroups) return groups
@@ -948,6 +953,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
       setOptimisticGroups(nextGroups)
       try {
         await onPersistGroups(nextGroups)
+        setOptimisticGroups(null)
       } catch {
         setOptimisticGroups(previousGroups)
       }
@@ -987,6 +993,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
       setOptimisticGroups(nextGroups)
       try {
         await onDeleteCollection(collectionId)
+        setOptimisticGroups(null)
       } catch {
         setOptimisticGroups(previousGroups)
       }
@@ -995,6 +1002,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
   )
 
   const handleStartInlineRename = useCallback((collection: Collection) => {
+    inlineRenameCancelledRef.current = false
     setEditingCollectionId(collection.id)
     setEditingName(collection.name)
   }, [])
@@ -1004,12 +1012,18 @@ const LeftSidebar = React.memo(function LeftSidebar({
   }, [])
 
   const handleCancelInlineRename = useCallback(() => {
+    inlineRenameCancelledRef.current = true
     setEditingCollectionId(null)
     setEditingName('')
   }, [])
 
   const handleSubmitInlineRename = useCallback(
     async (collectionId: string, nextName: string) => {
+      if (inlineRenameCancelledRef.current) {
+        inlineRenameCancelledRef.current = false
+        return
+      }
+
       const trimmedName = nextName.trim()
       if (!trimmedName) {
         handleCancelInlineRename()
@@ -1032,6 +1046,8 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
       try {
         await onRenameCollection(collectionId, trimmedName)
+        inlineRenameCancelledRef.current = false
+        setOptimisticGroups(null)
       } catch {
         setOptimisticGroups(previousGroups)
       }
@@ -1054,6 +1070,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
       try {
         await onChangeCollectionColor(collectionId, color)
+        setOptimisticGroups(null)
       } catch {
         setOptimisticGroups(previousGroups)
       }

--- a/src/components/raindrop/left-sidebar.tsx
+++ b/src/components/raindrop/left-sidebar.tsx
@@ -1,21 +1,49 @@
 import {
-  Inbox,
-  FileQuestion,
-  Trash2,
-  ChevronRight,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  closestCenter,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
   ChevronDown,
-  Plus,
+  ChevronRight,
+  FileQuestion,
+  FolderPlus,
+  Inbox,
+  Layers,
+  Merge,
   MoreHorizontal,
+  Plus,
   Search,
   Tag,
-  FolderPlus,
-  Layers,
-  Pencil,
-  Merge,
+  Trash2,
 } from 'lucide-react'
-import React, { useState, useCallback, useMemo } from 'react'
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from 'react'
 
 import { CollectionSearch } from '@/components/raindrop/collection-search'
+import { DragPreview } from '@/components/raindrop/drag-preview'
+import { DropIndicator } from '@/components/raindrop/drop-indicator'
 import { ThemeToggle } from '@/components/raindrop/theme-toggle'
 import { Button } from '@/components/ui/button'
 import {
@@ -23,6 +51,16 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,13 +74,13 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
-  SidebarMenuItem,
   SidebarMenuButton,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarGroupContent,
+  SidebarMenuItem,
   SidebarTrigger,
 } from '@/components/ui/sidebar'
 import {
@@ -50,14 +88,97 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import type { SystemCollection, Group, Collection } from '@/lib/types'
+import {
+  getCollectionDndId,
+  getGroupDndId,
+  findRootCollectionLocation,
+  moveRootCollection,
+  parseCollectionDndId,
+  parseGroupDndId,
+  updateRootCollection,
+} from '@/lib/collection-organization'
+import type { Collection, Group, SystemCollection } from '@/lib/types'
+import { cn } from '@/lib/utils'
 
-/** Stable click handler that stops propagation (used in dropdown triggers). */
-const stopPropagation = (e: React.MouseEvent) => e.stopPropagation()
+/**
+ * Preset colors shown in collection context-menu.
+ */
+const COLLECTION_COLOR_OPTIONS = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#06b6d4',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+] as const
+
+/**
+ * Stable click handler that stops propagation.
+ * @param event - Mouse event from nested actions
+ */
+function stopPropagation(event: React.MouseEvent) {
+  event.stopPropagation()
+}
+
+/**
+ * Remove one root collection from groups.
+ * @param groups - Current groups
+ * @param collectionId - Collection ID to remove
+ * @returns Updated groups
+ */
+function removeRootCollection(groups: Group[], collectionId: string): Group[] {
+  return groups.map((group) => ({
+    ...group,
+    collections: group.collections.filter(
+      (collection) => collection.id !== collectionId,
+    ),
+  }))
+}
+
+/**
+ * Serialize root-order structure for optimistic/server sync checks.
+ * @param groups - Groups to serialize
+ * @returns Stable string for comparison
+ */
+function serializeRootStructure(groups: Group[]): string {
+  return groups
+    .map(
+      (group) => `${group.id}:${group.collections.map((c) => c.id).join(',')}`,
+    )
+    .join('|')
+}
+
+/**
+ * Resolve drop indicator position from the active `over` ID.
+ * @param overId - Raw dnd-kit `over.id`
+ * @param groups - Current groups
+ * @returns Group and insertion index, or null
+ */
+function resolveDropIndicator(
+  overId: unknown,
+  groups: Group[],
+): { groupId: string; index: number } | null {
+  const overCollectionId = parseCollectionDndId(overId)
+  if (overCollectionId) {
+    const location = findRootCollectionLocation(groups, overCollectionId)
+    if (!location) return null
+    return { groupId: location.groupId, index: location.index }
+  }
+
+  const overGroupId = parseGroupDndId(overId)
+  if (overGroupId) {
+    const group = groups.find((currentGroup) => currentGroup.id === overGroupId)
+    if (!group) return null
+    return { groupId: overGroupId, index: group.collections.length }
+  }
+
+  return null
+}
 
 /**
  * Static map of system collection icon names to lucide components.
- * Defined at module level to avoid creating components during render.
  */
 const SYSTEM_ICON_MAP: Record<string, typeof Inbox> = {
   Inbox,
@@ -66,11 +187,7 @@ const SYSTEM_ICON_MAP: Record<string, typeof Inbox> = {
 }
 
 /**
- * Render the appropriate system collection icon.
- * @param iconName - Icon identifier from SystemCollection.icon
- * @param className - CSS class for the icon
- * @returns JSX element for the icon
- * @example <SystemIcon iconName="Inbox" className="h-4 w-4" />
+ * Render a system icon from a system collection icon key.
  */
 const SystemIcon = React.memo(function SystemIcon({
   iconName,
@@ -84,270 +201,22 @@ const SystemIcon = React.memo(function SystemIcon({
 })
 
 /**
- * A single collection row in the sidebar.
- * Extracted to allow useCallback for click handlers inside recursive rendering.
- */
-const CollectionItem = React.memo(function CollectionItem({
-  collection,
-  depth,
-  selectedCollectionId,
-  expandedCollections,
-  onSelectCollection,
-  onToggleCollection,
-  onEditCollection,
-  onDeleteCollection,
-  sidebarMenuButtonStyles,
-}: {
-  collection: Collection
-  depth: number
-  selectedCollectionId: string
-  expandedCollections: Set<string>
-  onSelectCollection: (id: string) => void
-  onToggleCollection: (id: string) => void
-  onEditCollection?: (collection: Collection) => void
-  onDeleteCollection?: (collectionId: string) => void
-  sidebarMenuButtonStyles: Record<number, React.CSSProperties>
-}) {
-  const isSelected = selectedCollectionId === collection.id
-  const hasChildren = collection.children && collection.children.length > 0
-  const isExpanded = expandedCollections.has(collection.id)
-
-  const handleClick = useCallback(
-    () => onSelectCollection(collection.id),
-    [onSelectCollection, collection.id],
-  )
-  const handleToggle = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    onToggleCollection(collection.id)
-  }
-  const handleEdit = useCallback(
-    () => onEditCollection?.(collection),
-    [onEditCollection, collection],
-  )
-  const handleDelete = useCallback(
-    () => onDeleteCollection?.(collection.id),
-    [onDeleteCollection, collection],
-  )
-
-  return (
-    <div>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          isActive={isSelected}
-          onClick={handleClick}
-          className="group/collection h-8 w-full"
-          style={
-            sidebarMenuButtonStyles[depth] || {
-              paddingLeft: `${12 + depth * 16}px`,
-            }
-          }
-        >
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {hasChildren ? (
-              <button
-                type="button"
-                onClick={handleToggle}
-                className="hover:bg-accent/50 flex-shrink-0 rounded p-0.5"
-              >
-                {isExpanded ? (
-                  <ChevronDown className="text-muted-foreground h-3 w-3" />
-                ) : (
-                  <ChevronRight className="text-muted-foreground h-3 w-3" />
-                )}
-              </button>
-            ) : (
-              <span className="w-4" />
-            )}
-
-            <div
-              className="h-3 w-3 flex-shrink-0 rounded-sm"
-              style={{ backgroundColor: collection.color || '#8b5cf6' }}
-            />
-
-            <span className="truncate text-sm">{collection.name}</span>
-          </div>
-
-          <div className="flex flex-shrink-0 items-center gap-1">
-            <span className="text-muted-foreground text-xs tabular-nums opacity-0 transition-opacity group-hover/collection:opacity-100">
-              {collection.count}
-            </span>
-            {(onEditCollection || onDeleteCollection) && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 opacity-0 group-hover/collection:opacity-100"
-                    onClick={stopPropagation}
-                  >
-                    <MoreHorizontal className="h-3 w-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-40">
-                  {onEditCollection && (
-                    <DropdownMenuItem onClick={handleEdit}>
-                      <Pencil className="mr-2 h-4 w-4" />
-                      Edit
-                    </DropdownMenuItem>
-                  )}
-                  {onDeleteCollection && (
-                    <>
-                      {onEditCollection && <DropdownMenuSeparator />}
-                      <DropdownMenuItem
-                        className="text-destructive"
-                        onClick={handleDelete}
-                      >
-                        <Trash2 className="mr-2 h-4 w-4" />
-                        Delete
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-          </div>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-
-      {hasChildren && isExpanded && (
-        <div>
-          {collection.children!.map((child) => (
-            <CollectionItem
-              key={child.id}
-              collection={child}
-              depth={depth + 1}
-              selectedCollectionId={selectedCollectionId}
-              expandedCollections={expandedCollections}
-              onSelectCollection={onSelectCollection}
-              onToggleCollection={onToggleCollection}
-              onEditCollection={onEditCollection}
-              onDeleteCollection={onDeleteCollection}
-              sidebarMenuButtonStyles={sidebarMenuButtonStyles}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-})
-
-/**
- * A single group section in the sidebar with its collections.
- * Extracted to allow useCallback for the Collapsible onOpenChange.
- */
-const GroupSection = React.memo(function GroupSection({
-  group,
-  isExpanded,
-  selectedCollectionId,
-  expandedCollections,
-  onToggleGroup,
-  onSelectCollection,
-  onToggleCollection,
-  onAddCollection,
-  onEditCollection,
-  onDeleteCollection,
-  sidebarMenuButtonStyles,
-}: {
-  group: Group
-  isExpanded: boolean
-  selectedCollectionId: string
-  expandedCollections: Set<string>
-  onToggleGroup: (id: string) => void
-  onSelectCollection: (id: string) => void
-  onToggleCollection: (id: string) => void
-  onAddCollection: () => void
-  onEditCollection?: (collection: Collection) => void
-  onDeleteCollection?: (collectionId: string) => void
-  sidebarMenuButtonStyles: Record<number, React.CSSProperties>
-}) {
-  const handleOpenChange = useCallback(
-    () => onToggleGroup(group.id),
-    [onToggleGroup, group.id],
-  )
-
-  return (
-    <Collapsible open={isExpanded} onOpenChange={handleOpenChange}>
-      <SidebarGroup>
-        <div className="group/groupheader flex items-center">
-          <CollapsibleTrigger asChild>
-            <SidebarGroupLabel className="text-muted-foreground hover:text-foreground flex-1 cursor-pointer px-3 text-xs font-medium tracking-wider uppercase transition-colors">
-              <span className="flex items-center gap-1">
-                {isExpanded ? (
-                  <ChevronDown className="h-3 w-3" />
-                ) : (
-                  <ChevronRight className="h-3 w-3" />
-                )}
-                {group.name}
-              </span>
-            </SidebarGroupLabel>
-          </CollapsibleTrigger>
-
-          <div className="flex items-center gap-0.5 pr-2 opacity-0 transition-opacity group-hover/groupheader:opacity-100 group-data-[collapsible=icon]:hidden">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-5 w-5">
-                  <MoreHorizontal className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onClick={onAddCollection}>
-                  <FolderPlus className="mr-2 h-4 w-4" />
-                  Add Collection
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem className="text-destructive">
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete Group
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-
-        <CollapsibleContent>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {group.collections.map((collection) => (
-                <CollectionItem
-                  key={collection.id}
-                  collection={collection}
-                  depth={0}
-                  selectedCollectionId={selectedCollectionId}
-                  expandedCollections={expandedCollections}
-                  onSelectCollection={onSelectCollection}
-                  onToggleCollection={onToggleCollection}
-                  onEditCollection={onEditCollection}
-                  onDeleteCollection={onDeleteCollection}
-                  sidebarMenuButtonStyles={sidebarMenuButtonStyles}
-                />
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </CollapsibleContent>
-      </SidebarGroup>
-    </Collapsible>
-  )
-})
-
-/**
- * A system collection row in the sidebar.
- * Extracted to allow useCallback for click handler.
+ * System collection row in the sidebar.
  */
 const SystemCollectionItem = React.memo(function SystemCollectionItem({
-  sc,
+  collection,
   isSelected,
   onSelectCollection,
   onEmptyTrash,
 }: {
-  sc: SystemCollection
+  collection: SystemCollection
   isSelected: boolean
   onSelectCollection: (id: string) => void
-  onEmptyTrash?: () => void
+  onEmptyTrash: () => Promise<void>
 }) {
-  const handleClick = useCallback(
-    () => onSelectCollection(sc.id),
-    [onSelectCollection, sc.id],
-  )
+  const handleClick = useCallback(() => {
+    onSelectCollection(collection.id)
+  }, [collection.id, onSelectCollection])
 
   return (
     <SidebarMenuItem>
@@ -355,15 +224,15 @@ const SystemCollectionItem = React.memo(function SystemCollectionItem({
         isActive={isSelected}
         onClick={handleClick}
         className="group/syscol h-8"
-        tooltip={sc.name}
+        tooltip={collection.name}
       >
-        <SystemIcon iconName={sc.icon} className="h-4 w-4" />
-        <span className="flex-1 truncate">{sc.name}</span>
-        <div className="flex flex-shrink-0 items-center gap-1">
+        <SystemIcon iconName={collection.icon} className="h-4 w-4" />
+        <span className="flex-1 truncate">{collection.name}</span>
+        <div className="flex shrink-0 items-center gap-1">
           <span className="text-muted-foreground text-xs tabular-nums">
-            {sc.count}
+            {collection.count}
           </span>
-          {sc.id === 'trash' && onEmptyTrash && (
+          {collection.id === 'trash' && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -393,68 +262,571 @@ const SystemCollectionItem = React.memo(function SystemCollectionItem({
 })
 
 /**
- * Props for the LeftSidebar component.
+ * Single collection row renderer (supports inline rename and context menu).
+ */
+const CollectionRow = React.memo(function CollectionRow({
+  collection,
+  depth,
+  selectedCollectionId,
+  expandedCollections,
+  onSelectCollection,
+  onToggleCollection,
+  onDeleteCollection,
+  onMoveCollectionToGroup,
+  onChangeCollectionColor,
+  onStartInlineRename,
+  onSubmitInlineRename,
+  onCancelInlineRename,
+  editingCollectionId,
+  editingName,
+  onEditingNameChange,
+  groups,
+  sidebarMenuButtonStyles,
+  sortable,
+  isRoot,
+}: {
+  collection: Collection
+  depth: number
+  selectedCollectionId: string
+  expandedCollections: Set<string>
+  onSelectCollection: (id: string) => void
+  onToggleCollection: (id: string) => void
+  onDeleteCollection: (collectionId: string) => Promise<void>
+  onMoveCollectionToGroup: (
+    collectionId: string,
+    targetGroupId: string,
+  ) => Promise<void>
+  onChangeCollectionColor: (
+    collectionId: string,
+    color: string,
+  ) => Promise<void>
+  onStartInlineRename: (collection: Collection) => void
+  onSubmitInlineRename: (
+    collectionId: string,
+    nextName: string,
+  ) => Promise<void>
+  onCancelInlineRename: () => void
+  editingCollectionId: string | null
+  editingName: string
+  onEditingNameChange: (nextName: string) => void
+  groups: Group[]
+  sidebarMenuButtonStyles: Record<number, CSSProperties>
+  sortable?: {
+    setNodeRef: (node: HTMLElement | null) => void
+    attributes: DraggableAttributes
+    listeners?: DraggableSyntheticListeners
+    style: CSSProperties
+    isDragging: boolean
+  }
+  isRoot: boolean
+}) {
+  const isSelected = selectedCollectionId === collection.id
+  const hasChildren = (collection.children?.length ?? 0) > 0
+  const isExpanded = expandedCollections.has(collection.id)
+  const isEditing = editingCollectionId === collection.id
+
+  const handleSelect = useCallback(() => {
+    onSelectCollection(collection.id)
+  }, [collection.id, onSelectCollection])
+
+  function handleToggle(event: React.MouseEvent) {
+    event.stopPropagation()
+    onToggleCollection(collection.id)
+  }
+
+  function handleDoubleClick(event: React.MouseEvent) {
+    if (!isRoot) return
+    event.stopPropagation()
+    onStartInlineRename(collection)
+  }
+
+  const handleSubmitRename = useCallback(async () => {
+    await onSubmitInlineRename(collection.id, editingName)
+  }, [collection.id, editingName, onSubmitInlineRename])
+
+  const handleContextRename = useCallback(() => {
+    onStartInlineRename(collection)
+  }, [collection, onStartInlineRename])
+
+  const handleContextDelete = useCallback(() => {
+    void onDeleteCollection(collection.id)
+  }, [collection.id, onDeleteCollection])
+
+  const moveToGroupHandlers = useMemo(() => {
+    return new Map(
+      groups.map((group) => {
+        const handler = () => {
+          void onMoveCollectionToGroup(collection.id, group.id)
+        }
+        return [group.id, handler]
+      }),
+    )
+  }, [collection.id, groups, onMoveCollectionToGroup])
+
+  const colorHandlers = useMemo(() => {
+    return new Map(
+      COLLECTION_COLOR_OPTIONS.map((color) => {
+        const handler = () => {
+          void onChangeCollectionColor(collection.id, color)
+        }
+        return [color, handler]
+      }),
+    )
+  }, [collection.id, onChangeCollectionColor])
+
+  const row = (
+    <div
+      ref={sortable?.setNodeRef}
+      style={sortable?.style}
+      data-testid={isRoot ? `sidebar-collection-${collection.id}` : undefined}
+      className={cn(sortable?.isDragging && 'opacity-50')}
+    >
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          isActive={isSelected}
+          onClick={handleSelect}
+          className="group/collection h-8 w-full"
+          style={
+            sidebarMenuButtonStyles[depth] || {
+              paddingLeft: `${12 + depth * 16}px`,
+            }
+          }
+          {...(sortable?.attributes ?? {})}
+          {...(sortable?.listeners ?? {})}
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            {hasChildren ? (
+              <button
+                type="button"
+                onClick={handleToggle}
+                className="hover:bg-accent/50 shrink-0 rounded p-0.5"
+              >
+                {isExpanded ? (
+                  <ChevronDown className="text-muted-foreground h-3 w-3" />
+                ) : (
+                  <ChevronRight className="text-muted-foreground h-3 w-3" />
+                )}
+              </button>
+            ) : (
+              <span className="w-4" />
+            )}
+
+            <div
+              data-testid={`collection-color-${collection.id}`}
+              className="h-3 w-3 shrink-0 rounded-sm"
+              style={{ backgroundColor: collection.color || '#8b5cf6' }}
+            />
+
+            {isEditing ? (
+              <input
+                value={editingName}
+                onChange={(event) => onEditingNameChange(event.target.value)}
+                onClick={stopPropagation}
+                onBlur={() => {
+                  void handleSubmitRename()
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    void handleSubmitRename()
+                  }
+                  if (event.key === 'Escape') {
+                    onCancelInlineRename()
+                  }
+                }}
+                autoFocus
+                className="bg-background h-6 min-w-0 flex-1 rounded border px-1.5 text-sm outline-none"
+              />
+            ) : (
+              <span
+                className="truncate text-sm"
+                onDoubleClick={handleDoubleClick}
+                title={collection.name}
+              >
+                {collection.name}
+              </span>
+            )}
+          </div>
+
+          <span className="text-muted-foreground text-xs tabular-nums opacity-0 transition-opacity group-hover/collection:opacity-100">
+            {collection.count}
+          </span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </div>
+  )
+
+  const maybeContextMenu = isRoot ? (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuItem onClick={handleContextRename}>Rename</ContextMenuItem>
+        <ContextMenuItem variant="destructive" onClick={handleContextDelete}>
+          Delete
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>Move to Group</ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-48">
+            {groups.map((group) => (
+              <ContextMenuItem
+                key={group.id}
+                disabled={group.id === collection.groupId}
+                onClick={moveToGroupHandlers.get(group.id)}
+              >
+                {group.name}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>Change Color</ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-40">
+            {COLLECTION_COLOR_OPTIONS.map((color) => (
+              <ContextMenuItem key={color} onClick={colorHandlers.get(color)}>
+                <span
+                  className="mr-2 inline-block h-3 w-3 rounded-sm border"
+                  style={{ backgroundColor: color }}
+                />
+                {color}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+      </ContextMenuContent>
+    </ContextMenu>
+  ) : (
+    row
+  )
+
+  return (
+    <div>
+      {maybeContextMenu}
+      {hasChildren && isExpanded && (
+        <div>
+          {collection.children?.map((childCollection) => (
+            <CollectionRow
+              key={childCollection.id}
+              collection={childCollection}
+              depth={depth + 1}
+              selectedCollectionId={selectedCollectionId}
+              expandedCollections={expandedCollections}
+              onSelectCollection={onSelectCollection}
+              onToggleCollection={onToggleCollection}
+              onDeleteCollection={onDeleteCollection}
+              onMoveCollectionToGroup={onMoveCollectionToGroup}
+              onChangeCollectionColor={onChangeCollectionColor}
+              onStartInlineRename={onStartInlineRename}
+              onSubmitInlineRename={onSubmitInlineRename}
+              onCancelInlineRename={onCancelInlineRename}
+              editingCollectionId={editingCollectionId}
+              editingName={editingName}
+              onEditingNameChange={onEditingNameChange}
+              groups={groups}
+              sidebarMenuButtonStyles={sidebarMenuButtonStyles}
+              isRoot={false}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+})
+
+/**
+ * Sortable root collection row wrapper.
+ */
+const SortableRootCollectionRow = React.memo(
+  function SortableRootCollectionRow({
+    collection,
+    selectedCollectionId,
+    expandedCollections,
+    onSelectCollection,
+    onToggleCollection,
+    onDeleteCollection,
+    onMoveCollectionToGroup,
+    onChangeCollectionColor,
+    onStartInlineRename,
+    onSubmitInlineRename,
+    onCancelInlineRename,
+    editingCollectionId,
+    editingName,
+    onEditingNameChange,
+    groups,
+    sidebarMenuButtonStyles,
+  }: {
+    collection: Collection
+    selectedCollectionId: string
+    expandedCollections: Set<string>
+    onSelectCollection: (id: string) => void
+    onToggleCollection: (id: string) => void
+    onDeleteCollection: (collectionId: string) => Promise<void>
+    onMoveCollectionToGroup: (
+      collectionId: string,
+      targetGroupId: string,
+    ) => Promise<void>
+    onChangeCollectionColor: (
+      collectionId: string,
+      color: string,
+    ) => Promise<void>
+    onStartInlineRename: (collection: Collection) => void
+    onSubmitInlineRename: (
+      collectionId: string,
+      nextName: string,
+    ) => Promise<void>
+    onCancelInlineRename: () => void
+    editingCollectionId: string | null
+    editingName: string
+    onEditingNameChange: (nextName: string) => void
+    groups: Group[]
+    sidebarMenuButtonStyles: Record<number, CSSProperties>
+  }) {
+    const {
+      attributes,
+      listeners,
+      setNodeRef,
+      transform,
+      transition,
+      isDragging,
+    } = useSortable({
+      id: getCollectionDndId(collection.id),
+      data: { collectionId: collection.id, groupId: collection.groupId },
+    })
+
+    const style = useMemo<CSSProperties>(() => {
+      return {
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }
+    }, [transform, transition])
+
+    const sortableProps = useMemo(
+      () => ({
+        setNodeRef,
+        attributes,
+        listeners: listeners ?? undefined,
+        style,
+        isDragging,
+      }),
+      [attributes, isDragging, listeners, setNodeRef, style],
+    )
+
+    return (
+      <CollectionRow
+        collection={collection}
+        depth={0}
+        selectedCollectionId={selectedCollectionId}
+        expandedCollections={expandedCollections}
+        onSelectCollection={onSelectCollection}
+        onToggleCollection={onToggleCollection}
+        onDeleteCollection={onDeleteCollection}
+        onMoveCollectionToGroup={onMoveCollectionToGroup}
+        onChangeCollectionColor={onChangeCollectionColor}
+        onStartInlineRename={onStartInlineRename}
+        onSubmitInlineRename={onSubmitInlineRename}
+        onCancelInlineRename={onCancelInlineRename}
+        editingCollectionId={editingCollectionId}
+        editingName={editingName}
+        onEditingNameChange={onEditingNameChange}
+        groups={groups}
+        sidebarMenuButtonStyles={sidebarMenuButtonStyles}
+        isRoot
+        sortable={sortableProps}
+      />
+    )
+  },
+)
+
+/**
+ * One group section with sortable root collections.
+ */
+const GroupSection = React.memo(function GroupSection({
+  group,
+  isExpanded,
+  selectedCollectionId,
+  expandedCollections,
+  onToggleGroup,
+  onSelectCollection,
+  onToggleCollection,
+  onAddCollection,
+  onDeleteCollection,
+  onMoveCollectionToGroup,
+  onChangeCollectionColor,
+  onStartInlineRename,
+  onSubmitInlineRename,
+  onCancelInlineRename,
+  editingCollectionId,
+  editingName,
+  onEditingNameChange,
+  sidebarMenuButtonStyles,
+  groups,
+  dropIndicator,
+}: {
+  group: Group
+  isExpanded: boolean
+  selectedCollectionId: string
+  expandedCollections: Set<string>
+  onToggleGroup: (groupId: string) => void
+  onSelectCollection: (collectionId: string) => void
+  onToggleCollection: (collectionId: string) => void
+  onAddCollection: () => void
+  onDeleteCollection: (collectionId: string) => Promise<void>
+  onMoveCollectionToGroup: (
+    collectionId: string,
+    targetGroupId: string,
+  ) => Promise<void>
+  onChangeCollectionColor: (
+    collectionId: string,
+    color: string,
+  ) => Promise<void>
+  onStartInlineRename: (collection: Collection) => void
+  onSubmitInlineRename: (
+    collectionId: string,
+    nextName: string,
+  ) => Promise<void>
+  onCancelInlineRename: () => void
+  editingCollectionId: string | null
+  editingName: string
+  onEditingNameChange: (nextName: string) => void
+  sidebarMenuButtonStyles: Record<number, CSSProperties>
+  groups: Group[]
+  dropIndicator: { groupId: string; index: number } | null
+}) {
+  const handleOpenChange = useCallback(() => {
+    onToggleGroup(group.id)
+  }, [group.id, onToggleGroup])
+
+  const sortableIds = useMemo(() => {
+    return group.collections.map((collection) =>
+      getCollectionDndId(collection.id),
+    )
+  }, [group.collections])
+
+  const { setNodeRef } = useDroppable({
+    id: getGroupDndId(group.id),
+    data: { groupId: group.id },
+  })
+
+  return (
+    <Collapsible open={isExpanded} onOpenChange={handleOpenChange}>
+      <SidebarGroup data-testid={`sidebar-group-${group.id}`}>
+        <div className="group/groupheader flex items-center">
+          <CollapsibleTrigger asChild>
+            <SidebarGroupLabel className="text-muted-foreground hover:text-foreground flex-1 cursor-pointer px-3 text-xs font-medium tracking-wider uppercase transition-colors">
+              <span className="flex items-center gap-1">
+                {isExpanded ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronRight className="h-3 w-3" />
+                )}
+                {group.name}
+              </span>
+            </SidebarGroupLabel>
+          </CollapsibleTrigger>
+
+          <div className="flex items-center gap-0.5 pr-2 opacity-0 transition-opacity group-hover/groupheader:opacity-100 group-data-[collapsible=icon]:hidden">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-5 w-5">
+                  <MoreHorizontal className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem onClick={onAddCollection}>
+                  <FolderPlus className="mr-2 h-4 w-4" />
+                  Add Collection
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-destructive" disabled>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete Group
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+
+        <CollapsibleContent>
+          <div ref={setNodeRef}>
+            <SidebarGroupContent>
+              <SortableContext
+                items={sortableIds}
+                strategy={verticalListSortingStrategy}
+              >
+                <SidebarMenu>
+                  {group.collections.map((collection, index) => (
+                    <React.Fragment key={collection.id}>
+                      {dropIndicator?.groupId === group.id &&
+                        dropIndicator.index === index && (
+                          <DropIndicator
+                            isActive
+                            position="before"
+                            data-testid={`drop-indicator-${group.id}-${index}`}
+                          />
+                        )}
+                      <SortableRootCollectionRow
+                        collection={collection}
+                        selectedCollectionId={selectedCollectionId}
+                        expandedCollections={expandedCollections}
+                        onSelectCollection={onSelectCollection}
+                        onToggleCollection={onToggleCollection}
+                        onDeleteCollection={onDeleteCollection}
+                        onMoveCollectionToGroup={onMoveCollectionToGroup}
+                        onChangeCollectionColor={onChangeCollectionColor}
+                        onStartInlineRename={onStartInlineRename}
+                        onSubmitInlineRename={onSubmitInlineRename}
+                        onCancelInlineRename={onCancelInlineRename}
+                        editingCollectionId={editingCollectionId}
+                        editingName={editingName}
+                        onEditingNameChange={onEditingNameChange}
+                        groups={groups}
+                        sidebarMenuButtonStyles={sidebarMenuButtonStyles}
+                      />
+                    </React.Fragment>
+                  ))}
+                  {dropIndicator?.groupId === group.id &&
+                    dropIndicator.index === group.collections.length && (
+                      <DropIndicator
+                        isActive
+                        position="after"
+                        data-testid={`drop-indicator-${group.id}-end`}
+                      />
+                    )}
+                </SidebarMenu>
+              </SortableContext>
+            </SidebarGroupContent>
+          </div>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
+  )
+})
+
+/**
+ * Props for LeftSidebar.
  */
 interface LeftSidebarProps {
-  /** System-level collections (All Bookmarks, Unsorted, Trash) */
   systemCollections: SystemCollection[]
-  /** Groups containing user collections */
   groups: Group[]
-  /** Currently selected collection ID */
   selectedCollectionId: string
-  /** Callback when a collection is selected */
   onSelectCollection: (id: string) => void
-  /** Callback to open the add bookmark dialog */
   onAddBookmark: () => void
-  /** Callback to open the add collection dialog */
   onAddCollection: () => void
-  /** Callback to open the add group dialog */
   onAddGroup: () => void
-  /** Callback to open the tag management dialog */
   onManageTags: () => void
-  /** Callback to open collection in edit mode */
-  onEditCollection: (collection: Collection) => void
-  /** Callback to delete a collection */
   onDeleteCollection: (collectionId: string) => Promise<void>
-  /** Callback to empty the trash */
   onEmptyTrash: () => Promise<void>
-  /** Callback to open the merge collections dialog */
   onMergeCollections: () => void
+  onPersistGroups: (groups: Group[]) => Promise<void>
+  onRenameCollection: (collectionId: string, title: string) => Promise<void>
+  onChangeCollectionColor: (
+    collectionId: string,
+    color: string,
+  ) => Promise<void>
 }
 
 /**
- * Left sidebar navigation for the Raindrop.io bookmark manager.
- * Contains system collections (All, Unsorted, Trash), user groups
- * with nested collection trees, and action buttons.
- *
- * @param systemCollections - Pinned system-level collections
- * @param groups - User-created groups containing collections
- * @param selectedCollectionId - Currently active collection ID
- * @param onSelectCollection - Fires when user clicks a collection
- * @param onAddBookmark - Opens the add bookmark dialog
- * @param onAddCollection - Opens the add collection dialog
- * @param onAddGroup - Opens the add group dialog
- * @param onManageTags - Opens the tag management dialog
- * @param onEditCollection - Opens collection in edit mode
- * @param onDeleteCollection - Deletes a collection by ID
- * @param onEmptyTrash - Empties the trash
- * @param onMergeCollections - Opens the merge collections dialog
- *
- * @example
- *   <LeftSidebar
- *     systemCollections={systemCollections}
- *     groups={groups}
- *     selectedCollectionId="all"
- *     onSelectCollection={setSelectedCollectionId}
- *     onAddBookmark={() => setIsAddBookmarkOpen(true)}
- *     onAddCollection={() => setIsCollectionDialogOpen(true)}
- *     onAddGroup={() => setIsGroupDialogOpen(true)}
- *     onManageTags={() => setIsTagManagementOpen(true)}
- *     onEditCollection={(collection) => handleEditCollection(collection)}
- *     onDeleteCollection={(id) => handleDeleteCollection(id)}
- *     onEmptyTrash={() => handleEmptyTrash()}
- *     onMergeCollections={() => handleOpenMerge()}
- *   />
+ * Left sidebar navigation with system collections, grouped collections, and DnD.
  */
 const LeftSidebar = React.memo(function LeftSidebar({
   systemCollections,
@@ -465,21 +837,61 @@ const LeftSidebar = React.memo(function LeftSidebar({
   onAddCollection,
   onAddGroup,
   onManageTags,
-  onEditCollection,
   onDeleteCollection,
   onEmptyTrash,
   onMergeCollections,
+  onPersistGroups,
+  onRenameCollection,
+  onChangeCollectionColor,
 }: LeftSidebarProps) {
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    new Set(groups.map((g) => g.id)),
+  const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(
+    new Set(),
   )
   const [expandedCollections, setExpandedCollections] = useState<Set<string>>(
     new Set(),
   )
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [optimisticGroups, setOptimisticGroups] = useState<Group[] | null>(null)
+  const [editingCollectionId, setEditingCollectionId] = useState<string | null>(
+    null,
+  )
+  const [editingName, setEditingName] = useState('')
+  const [activeDragCollectionId, setActiveDragCollectionId] = useState<
+    string | null
+  >(null)
+  const [dropIndicator, setDropIndicator] = useState<{
+    groupId: string
+    index: number
+  } | null>(null)
 
-  const handleOpenSearch = useCallback(() => setIsSearchOpen(true), [])
-  const handleCloseSearch = useCallback(() => setIsSearchOpen(false), [])
+  const displayedGroups = useMemo(() => {
+    if (!optimisticGroups) return groups
+    if (
+      serializeRootStructure(optimisticGroups) ===
+      serializeRootStructure(groups)
+    ) {
+      return groups
+    }
+    return optimisticGroups
+  }, [groups, optimisticGroups])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const handleOpenSearch = useCallback(() => {
+    setIsSearchOpen(true)
+  }, [])
+
+  const handleCloseSearch = useCallback(() => {
+    setIsSearchOpen(false)
+  }, [])
+
   const handleSearchSelect = useCallback(
     (collectionId: string) => {
       onSelectCollection(collectionId)
@@ -488,13 +900,9 @@ const LeftSidebar = React.memo(function LeftSidebar({
     [onSelectCollection],
   )
 
-  /**
-   * Toggle a group's expanded/collapsed state.
-   * @param groupId - The group ID to toggle
-   */
   const toggleGroup = useCallback((groupId: string) => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev)
+    setCollapsedGroupIds((previous) => {
+      const next = new Set(previous)
       if (next.has(groupId)) {
         next.delete(groupId)
       } else {
@@ -504,13 +912,9 @@ const LeftSidebar = React.memo(function LeftSidebar({
     })
   }, [])
 
-  /**
-   * Toggle a collection's expanded/collapsed state (for nested children).
-   * @param collectionId - The collection ID to toggle
-   */
   const toggleCollection = useCallback((collectionId: string) => {
-    setExpandedCollections((prev) => {
-      const next = new Set(prev)
+    setExpandedCollections((previous) => {
+      const next = new Set(previous)
       if (next.has(collectionId)) {
         next.delete(collectionId)
       } else {
@@ -520,15 +924,201 @@ const LeftSidebar = React.memo(function LeftSidebar({
     })
   }, [])
 
-  /**
-   * Pre-computed indentation styles for collection tree depths.
-   */
   const sidebarMenuButtonStyles = useMemo(() => {
-    const styles: Record<number, React.CSSProperties> = {}
-    for (let d = 0; d <= 5; d++) {
-      styles[d] = { paddingLeft: `${12 + d * 16}px` }
+    const styles: Record<number, CSSProperties> = {}
+    for (let depth = 0; depth <= 5; depth += 1) {
+      styles[depth] = { paddingLeft: `${12 + depth * 16}px` }
     }
     return styles
+  }, [])
+
+  const activeDragCollection = useMemo(() => {
+    if (!activeDragCollectionId) return undefined
+    for (const group of displayedGroups) {
+      const found = group.collections.find(
+        (collection) => collection.id === activeDragCollectionId,
+      )
+      if (found) return found
+    }
+    return undefined
+  }, [activeDragCollectionId, displayedGroups])
+
+  const handlePersistGroups = useCallback(
+    async (nextGroups: Group[], previousGroups: Group[]) => {
+      setOptimisticGroups(nextGroups)
+      try {
+        await onPersistGroups(nextGroups)
+      } catch {
+        setOptimisticGroups(previousGroups)
+      }
+    },
+    [onPersistGroups],
+  )
+
+  const handleMoveCollectionToGroup = useCallback(
+    async (collectionId: string, targetGroupId: string) => {
+      const previousGroups = displayedGroups
+      const targetGroup = previousGroups.find(
+        (group) => group.id === targetGroupId,
+      )
+      if (!targetGroup) return
+
+      const nextGroups = moveRootCollection(
+        previousGroups,
+        collectionId,
+        targetGroupId,
+        targetGroup.collections.length,
+      )
+      if (
+        serializeRootStructure(previousGroups) ===
+        serializeRootStructure(nextGroups)
+      ) {
+        return
+      }
+      await handlePersistGroups(nextGroups, previousGroups)
+    },
+    [displayedGroups, handlePersistGroups],
+  )
+
+  const handleDeleteWithOptimistic = useCallback(
+    async (collectionId: string) => {
+      const previousGroups = displayedGroups
+      const nextGroups = removeRootCollection(previousGroups, collectionId)
+      setOptimisticGroups(nextGroups)
+      try {
+        await onDeleteCollection(collectionId)
+      } catch {
+        setOptimisticGroups(previousGroups)
+      }
+    },
+    [displayedGroups, onDeleteCollection],
+  )
+
+  const handleStartInlineRename = useCallback((collection: Collection) => {
+    setEditingCollectionId(collection.id)
+    setEditingName(collection.name)
+  }, [])
+
+  const handleEditingNameChange = useCallback((nextName: string) => {
+    setEditingName(nextName)
+  }, [])
+
+  const handleCancelInlineRename = useCallback(() => {
+    setEditingCollectionId(null)
+    setEditingName('')
+  }, [])
+
+  const handleSubmitInlineRename = useCallback(
+    async (collectionId: string, nextName: string) => {
+      const trimmedName = nextName.trim()
+      if (!trimmedName) {
+        handleCancelInlineRename()
+        return
+      }
+
+      const previousGroups = displayedGroups
+      const nextGroups = updateRootCollection(
+        previousGroups,
+        collectionId,
+        (item) => ({
+          ...item,
+          name: trimmedName,
+        }),
+      )
+
+      setOptimisticGroups(nextGroups)
+      setEditingCollectionId(null)
+      setEditingName('')
+
+      try {
+        await onRenameCollection(collectionId, trimmedName)
+      } catch {
+        setOptimisticGroups(previousGroups)
+      }
+    },
+    [displayedGroups, handleCancelInlineRename, onRenameCollection],
+  )
+
+  const handleChangeColor = useCallback(
+    async (collectionId: string, color: string) => {
+      const previousGroups = displayedGroups
+      const nextGroups = updateRootCollection(
+        previousGroups,
+        collectionId,
+        (item) => ({
+          ...item,
+          color,
+        }),
+      )
+      setOptimisticGroups(nextGroups)
+
+      try {
+        await onChangeCollectionColor(collectionId, color)
+      } catch {
+        setOptimisticGroups(previousGroups)
+      }
+    },
+    [displayedGroups, onChangeCollectionColor],
+  )
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setEditingCollectionId(null)
+    setEditingName('')
+    setActiveDragCollectionId(parseCollectionDndId(event.active.id))
+  }, [])
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      setDropIndicator(resolveDropIndicator(event.over?.id, displayedGroups))
+    },
+    [displayedGroups],
+  )
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const activeCollectionId = parseCollectionDndId(event.active.id)
+      const dropTarget = resolveDropIndicator(event.over?.id, displayedGroups)
+
+      setActiveDragCollectionId(null)
+      setDropIndicator(null)
+
+      if (!activeCollectionId || !dropTarget) return
+
+      const sourceLocation = findRootCollectionLocation(
+        displayedGroups,
+        activeCollectionId,
+      )
+      if (!sourceLocation) return
+
+      let toIndex = dropTarget.index
+      if (
+        sourceLocation.groupId === dropTarget.groupId &&
+        sourceLocation.index < dropTarget.index
+      ) {
+        toIndex -= 1
+      }
+
+      const nextGroups = moveRootCollection(
+        displayedGroups,
+        activeCollectionId,
+        dropTarget.groupId,
+        toIndex,
+      )
+      if (
+        serializeRootStructure(displayedGroups) ===
+        serializeRootStructure(nextGroups)
+      ) {
+        return
+      }
+
+      await handlePersistGroups(nextGroups, displayedGroups)
+    },
+    [displayedGroups, handlePersistGroups],
+  )
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDragCollectionId(null)
+    setDropIndicator(null)
   }, [])
 
   return (
@@ -546,7 +1136,6 @@ const LeftSidebar = React.memo(function LeftSidebar({
       </SidebarHeader>
 
       <SidebarContent>
-        {/* Quick Actions */}
         <SidebarGroup className="px-3 py-1 group-data-[collapsible=icon]:hidden">
           <div className="flex items-center gap-1">
             <Tooltip>
@@ -569,7 +1158,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 flex-shrink-0"
+                  className="h-8 w-8 shrink-0"
                   onClick={handleOpenSearch}
                 >
                   <Search className="h-3.5 w-3.5" />
@@ -580,11 +1169,10 @@ const LeftSidebar = React.memo(function LeftSidebar({
           </div>
         </SidebarGroup>
 
-        {/* Collection Search */}
         {isSearchOpen && (
           <div className="px-3 pb-1 group-data-[collapsible=icon]:hidden">
             <CollectionSearch
-              groups={groups}
+              groups={displayedGroups}
               onSelect={handleSearchSelect}
               onClose={handleCloseSearch}
             />
@@ -592,18 +1180,17 @@ const LeftSidebar = React.memo(function LeftSidebar({
         )}
 
         <ScrollArea className="flex-1">
-          {/* System Collections */}
           <SidebarGroup>
             <SidebarGroupLabel className="text-muted-foreground px-3 text-xs font-medium tracking-wider uppercase">
               Library
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {systemCollections.map((sc) => (
+                {systemCollections.map((collection) => (
                   <SystemCollectionItem
-                    key={sc.id}
-                    sc={sc}
-                    isSelected={selectedCollectionId === sc.id}
+                    key={collection.id}
+                    collection={collection}
+                    isSelected={selectedCollectionId === collection.id}
                     onSelectCollection={onSelectCollection}
                     onEmptyTrash={onEmptyTrash}
                   />
@@ -614,23 +1201,43 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
           <Separator className="mx-3 my-1" />
 
-          {/* Groups with Collections */}
-          {groups.map((group) => (
-            <GroupSection
-              key={group.id}
-              group={group}
-              isExpanded={expandedGroups.has(group.id)}
-              selectedCollectionId={selectedCollectionId}
-              expandedCollections={expandedCollections}
-              onToggleGroup={toggleGroup}
-              onSelectCollection={onSelectCollection}
-              onToggleCollection={toggleCollection}
-              onAddCollection={onAddCollection}
-              onEditCollection={onEditCollection}
-              onDeleteCollection={onDeleteCollection}
-              sidebarMenuButtonStyles={sidebarMenuButtonStyles}
-            />
-          ))}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
+            {displayedGroups.map((group) => (
+              <GroupSection
+                key={group.id}
+                group={group}
+                isExpanded={!collapsedGroupIds.has(group.id)}
+                selectedCollectionId={selectedCollectionId}
+                expandedCollections={expandedCollections}
+                onToggleGroup={toggleGroup}
+                onSelectCollection={onSelectCollection}
+                onToggleCollection={toggleCollection}
+                onAddCollection={onAddCollection}
+                onDeleteCollection={handleDeleteWithOptimistic}
+                onMoveCollectionToGroup={handleMoveCollectionToGroup}
+                onChangeCollectionColor={handleChangeColor}
+                onStartInlineRename={handleStartInlineRename}
+                onSubmitInlineRename={handleSubmitInlineRename}
+                onCancelInlineRename={handleCancelInlineRename}
+                editingCollectionId={editingCollectionId}
+                editingName={editingName}
+                onEditingNameChange={handleEditingNameChange}
+                sidebarMenuButtonStyles={sidebarMenuButtonStyles}
+                groups={displayedGroups}
+                dropIndicator={dropIndicator}
+              />
+            ))}
+            <DragOverlay>
+              <DragPreview collection={activeDragCollection} />
+            </DragOverlay>
+          </DndContext>
         </ScrollArea>
       </SidebarContent>
 
@@ -686,5 +1293,6 @@ const LeftSidebar = React.memo(function LeftSidebar({
     </Sidebar>
   )
 })
+
 export { LeftSidebar }
 export default LeftSidebar

--- a/src/components/raindrop/raindrop-card.tsx
+++ b/src/components/raindrop/raindrop-card.tsx
@@ -230,6 +230,7 @@ const RaindropCard = React.memo(function RaindropCard({
             type={raindrop.type}
             size={24}
             className="shadow-sm ring-1 ring-black/10"
+            data-testid={`favicon-${raindrop.id}`}
           />
         </div>
 

--- a/src/components/raindrop/raindrop-list-item.tsx
+++ b/src/components/raindrop/raindrop-list-item.tsx
@@ -229,6 +229,7 @@ const RaindropListItem = React.memo(function RaindropListItem({
         type={raindrop.type}
         size={32}
         className="flex-shrink-0"
+        data-testid={`favicon-${raindrop.id}`}
       />
 
       {/* Title + Domain + Description */}

--- a/src/hooks/useCollectionsCrud.test.ts
+++ b/src/hooks/useCollectionsCrud.test.ts
@@ -2,6 +2,7 @@ import { act } from '@testing-library/react'
 import { describe, it } from 'vitest'
 
 import { useCollectionsCrud } from '@/hooks/useCollectionsCrud'
+import type { Group } from '@/lib/types'
 import { renderHookWithProviders } from '@test/render-with-providers'
 
 describe('useCollectionsCrud', () => {
@@ -44,6 +45,45 @@ describe('useCollectionsCrud', () => {
 
     await act(async () => {
       await result.current.emptyTrash()
+    })
+  })
+
+  it('persists group ordering via putUser', async () => {
+    const { result } = renderHookWithProviders(() => useCollectionsCrud())
+    const groups: Group[] = [
+      {
+        id: 'group-0',
+        name: 'Development',
+        collections: [
+          {
+            id: '100',
+            name: 'Development',
+            icon: 'Folder',
+            count: 10,
+            groupId: 'group-0',
+          },
+        ],
+      },
+    ]
+
+    await act(async () => {
+      await result.current.updateUserGroups(groups)
+    })
+  })
+
+  it('renames collection via updateCollection wrapper', async () => {
+    const { result } = renderHookWithProviders(() => useCollectionsCrud())
+
+    await act(async () => {
+      await result.current.renameCollection('100', 'Renamed in Sidebar')
+    })
+  })
+
+  it('updates collection color via putCollection', async () => {
+    const { result } = renderHookWithProviders(() => useCollectionsCrud())
+
+    await act(async () => {
+      await result.current.recolorCollection('100', '#3b82f6')
     })
   })
 })

--- a/src/hooks/useCollectionsCrud.ts
+++ b/src/hooks/useCollectionsCrud.ts
@@ -158,7 +158,7 @@ export function useCollectionsCrud(): UseCollectionsCrudReturn {
     async (id: string, color: string) => {
       const result = await putCollection({
         id: collectionIdToApi(id),
-        collectionUpdate: { color } as CollectionUpdate & { color?: string },
+        collectionUpdate: { color },
       })
       if ('data' in result) {
         toast.success('Collection color updated')

--- a/src/hooks/useCollectionsCrud.ts
+++ b/src/hooks/useCollectionsCrud.ts
@@ -2,12 +2,15 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import { collectionIdToApi } from '@/lib/api-mappers'
+import { toUserGroupPayload } from '@/lib/collection-organization'
+import type { Group } from '@/lib/types'
 import {
   useDeleteCollection99Mutation,
   useDeleteCollectionByIdMutation,
   usePostCollectionMutation,
   usePutCollectionByIdMutation,
   usePutCollectionsMergeMutation,
+  usePutUserMutation,
 } from '@/store/api/raindropApi'
 import type {
   CollectionCreate,
@@ -31,6 +34,7 @@ export function useCollectionsCrud(): UseCollectionsCrudReturn {
   const [deleteCollectionMutation] = useDeleteCollectionByIdMutation()
   const [mergeCollections] = usePutCollectionsMergeMutation()
   const [deleteCollection99] = useDeleteCollection99Mutation()
+  const [putUser] = usePutUserMutation()
 
   const createCollection = useCallback(
     async (data: CreateCollectionFormData) => {
@@ -114,12 +118,66 @@ export function useCollectionsCrud(): UseCollectionsCrudReturn {
     }
   }, [deleteCollection99])
 
+  /**
+   * Persist group ordering and group-to-collection mapping through `PUT /user`.
+   * @param groups - Current sidebar groups with ordered root collections
+   */
+  const updateUserGroups = useCallback(
+    async (groups: Group[]) => {
+      const result = await putUser({
+        userUpdate: {
+          groups: toUserGroupPayload(groups),
+        },
+      })
+      if (!('data' in result)) {
+        toast.error('Failed to save collection organization')
+        throw new Error('Failed to save collection organization')
+      }
+    },
+    [putUser],
+  )
+
+  /**
+   * Rename a collection by ID.
+   * @param id - Collection ID in UI format
+   * @param title - New collection title
+   */
+  const renameCollection = useCallback(
+    async (id: string, title: string) => {
+      await updateCollection(id, { title })
+    },
+    [updateCollection],
+  )
+
+  /**
+   * Update collection color by ID.
+   * @param id - Collection ID in UI format
+   * @param color - Hex color string
+   */
+  const recolorCollection = useCallback(
+    async (id: string, color: string) => {
+      const result = await putCollection({
+        id: collectionIdToApi(id),
+        collectionUpdate: { color } as CollectionUpdate & { color?: string },
+      })
+      if ('data' in result) {
+        toast.success('Collection color updated')
+      } else {
+        toast.error('Failed to update collection color')
+      }
+    },
+    [putCollection],
+  )
+
   return {
     createCollection,
     updateCollection,
     deleteCollection,
     merge,
     emptyTrash,
+    updateUserGroups,
+    renameCollection,
+    recolorCollection,
   }
 }
 
@@ -157,4 +215,10 @@ interface UseCollectionsCrudReturn {
   merge: (targetId: string, sourceIds: string[]) => Promise<void>
   /** Empty the trash (DELETE /collection/-99) */
   emptyTrash: () => Promise<void>
+  /** Persist current group ordering/membership using PUT /user */
+  updateUserGroups: (groups: Group[]) => Promise<void>
+  /** Rename collection title */
+  renameCollection: (id: string, title: string) => Promise<void>
+  /** Update collection color */
+  recolorCollection: (id: string, color: string) => Promise<void>
 }

--- a/src/lib/collection-organization.test.ts
+++ b/src/lib/collection-organization.test.ts
@@ -5,6 +5,7 @@ import type { Collection, Group } from '@/lib/types'
 import {
   findRootCollectionLocation,
   moveRootCollection,
+  parseCollectionId,
   reorderRootCollectionInGroup,
   toUserGroupPayload,
   updateRootCollection,
@@ -121,5 +122,10 @@ describe('collection-organization', () => {
         collections: [101],
       },
     ])
+  })
+
+  it('returns null for empty collection ids', () => {
+    expect(parseCollectionId('')).toBeNull()
+    expect(parseCollectionId('   ')).toBeNull()
   })
 })

--- a/src/lib/collection-organization.test.ts
+++ b/src/lib/collection-organization.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Collection, Group } from '@/lib/types'
+
+import {
+  findRootCollectionLocation,
+  moveRootCollection,
+  reorderRootCollectionInGroup,
+  toUserGroupPayload,
+  updateRootCollection,
+} from './collection-organization'
+
+/**
+ * Build a minimal root collection for organization tests.
+ * @param id - Collection ID
+ * @param name - Collection name
+ * @param groupId - Parent group ID
+ * @returns Collection test object
+ */
+function buildCollection(
+  id: string,
+  name: string,
+  groupId: string,
+): Collection {
+  return {
+    id,
+    name,
+    icon: 'Folder',
+    count: 0,
+    groupId,
+  }
+}
+
+/**
+ * Build test groups with deterministic ordering.
+ * @returns Two groups with three root collections total
+ */
+function buildGroups(): Group[] {
+  return [
+    {
+      id: 'group-0',
+      name: 'Development',
+      collections: [
+        buildCollection('100', 'Development', 'group-0'),
+        buildCollection('102', 'Research', 'group-0'),
+      ],
+    },
+    {
+      id: 'group-1',
+      name: 'Creative',
+      collections: [buildCollection('101', 'Design', 'group-1')],
+    },
+  ]
+}
+
+describe('collection-organization', () => {
+  it('finds root collection location by id', () => {
+    const groups = buildGroups()
+    expect(findRootCollectionLocation(groups, '102')).toEqual({
+      groupId: 'group-0',
+      index: 1,
+    })
+    expect(findRootCollectionLocation(groups, '999')).toBeNull()
+  })
+
+  it('moves root collection between groups', () => {
+    const groups = buildGroups()
+    const next = moveRootCollection(groups, '102', 'group-1', 1)
+
+    expect(next[0].collections.map((collection) => collection.id)).toEqual([
+      '100',
+    ])
+    expect(next[1].collections.map((collection) => collection.id)).toEqual([
+      '101',
+      '102',
+    ])
+    expect(next[1].collections[1].groupId).toBe('group-1')
+  })
+
+  it('reorders root collections within one group', () => {
+    const groups = buildGroups()
+    const next = reorderRootCollectionInGroup(groups, 'group-0', 0, 1)
+
+    expect(next[0].collections.map((collection) => collection.id)).toEqual([
+      '102',
+      '100',
+    ])
+    expect(next[1].collections.map((collection) => collection.id)).toEqual([
+      '101',
+    ])
+  })
+
+  it('updates a root collection immutably', () => {
+    const groups = buildGroups()
+    const next = updateRootCollection(groups, '101', (collection) => ({
+      ...collection,
+      name: 'Design System',
+      color: '#3b82f6',
+    }))
+
+    expect(next[1].collections[0].name).toBe('Design System')
+    expect(next[1].collections[0].color).toBe('#3b82f6')
+    expect(groups[1].collections[0].name).toBe('Design')
+  })
+
+  it('builds ordered user group payload for persistence', () => {
+    const groups = buildGroups()
+    const payload = toUserGroupPayload(groups)
+
+    expect(payload).toEqual([
+      {
+        title: 'Development',
+        hidden: false,
+        sort: 0,
+        collections: [100, 102],
+      },
+      {
+        title: 'Creative',
+        hidden: false,
+        sort: 1,
+        collections: [101],
+      },
+    ])
+  })
+})

--- a/src/lib/collection-organization.ts
+++ b/src/lib/collection-organization.ts
@@ -1,0 +1,248 @@
+import type { Group, Collection } from '@/lib/types'
+
+/**
+ * Prefix used for group container IDs in dnd-kit.
+ */
+export const GROUP_DND_ID_PREFIX = 'group:'
+
+/**
+ * Prefix used for collection item IDs in dnd-kit.
+ */
+export const COLLECTION_DND_ID_PREFIX = 'collection:'
+
+/**
+ * Shape of a persisted user group for `PUT /user` updates.
+ */
+export interface UserGroupPayload {
+  /** Human-readable group name */
+  title: string
+  /** Group visibility flag (false means visible) */
+  hidden: boolean
+  /** Group order in sidebar */
+  sort: number
+  /** Ordered root collection IDs in this group */
+  collections: number[]
+}
+
+/**
+ * Location information for a root collection in grouped data.
+ */
+export interface RootCollectionLocation {
+  /** Group ID containing the collection */
+  groupId: string
+  /** Collection index within the group's root collection array */
+  index: number
+}
+
+/**
+ * Parse a numeric collection ID from a UI string ID.
+ * @param collectionId - String collection ID from UI state
+ * @returns Parsed number or null for invalid values
+ * @example
+ * parseCollectionId('100') // => 100
+ * parseCollectionId('abc') // => null
+ */
+export function parseCollectionId(collectionId: string): number | null {
+  const parsed = Number(collectionId)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Build the draggable ID for a group drop container.
+ * @param groupId - Group identifier
+ * @returns DnD ID string
+ * @example
+ * getGroupDndId('group-0') // => 'group:group-0'
+ */
+export function getGroupDndId(groupId: string): string {
+  return `${GROUP_DND_ID_PREFIX}${groupId}`
+}
+
+/**
+ * Build the draggable ID for a collection row.
+ * @param collectionId - Collection identifier
+ * @returns DnD ID string
+ * @example
+ * getCollectionDndId('100') // => 'collection:100'
+ */
+export function getCollectionDndId(collectionId: string): string {
+  return `${COLLECTION_DND_ID_PREFIX}${collectionId}`
+}
+
+/**
+ * Extract a group ID from a dnd-kit item ID.
+ * @param dndId - Raw dnd-kit ID value
+ * @returns Group ID when the prefix matches, otherwise null
+ * @example
+ * parseGroupDndId('group:group-0') // => 'group-0'
+ */
+export function parseGroupDndId(dndId: unknown): string | null {
+  if (typeof dndId !== 'string') return null
+  if (!dndId.startsWith(GROUP_DND_ID_PREFIX)) return null
+  return dndId.slice(GROUP_DND_ID_PREFIX.length)
+}
+
+/**
+ * Extract a collection ID from a dnd-kit item ID.
+ * @param dndId - Raw dnd-kit ID value
+ * @returns Collection ID when the prefix matches, otherwise null
+ * @example
+ * parseCollectionDndId('collection:100') // => '100'
+ */
+export function parseCollectionDndId(dndId: unknown): string | null {
+  if (typeof dndId !== 'string') return null
+  if (!dndId.startsWith(COLLECTION_DND_ID_PREFIX)) return null
+  return dndId.slice(COLLECTION_DND_ID_PREFIX.length)
+}
+
+/**
+ * Find the root collection location for a collection ID.
+ * @param groups - Group tree to inspect
+ * @param collectionId - Root collection ID to locate
+ * @returns Location when found, otherwise null
+ * @example
+ * findRootCollectionLocation(groups, '100') // => { groupId: 'group-0', index: 0 }
+ */
+export function findRootCollectionLocation(
+  groups: Group[],
+  collectionId: string,
+): RootCollectionLocation | null {
+  for (const group of groups) {
+    const index = group.collections.findIndex((collection) => {
+      return collection.id === collectionId
+    })
+    if (index >= 0) {
+      return { groupId: group.id, index }
+    }
+  }
+  return null
+}
+
+/**
+ * Move a root collection between groups or within the same group.
+ * @param groups - Source groups
+ * @param collectionId - Root collection ID to move
+ * @param targetGroupId - Destination group ID
+ * @param targetIndex - Destination index in target group
+ * @returns Updated groups with reordered root collections
+ * @example
+ * moveRootCollection(groups, '100', 'group-1', 0)
+ */
+export function moveRootCollection(
+  groups: Group[],
+  collectionId: string,
+  targetGroupId: string,
+  targetIndex: number,
+): Group[] {
+  const sourceLocation = findRootCollectionLocation(groups, collectionId)
+  if (!sourceLocation) return groups
+
+  const sourceGroupIndex = groups.findIndex(
+    (group) => group.id === sourceLocation.groupId,
+  )
+  const targetGroupIndex = groups.findIndex(
+    (group) => group.id === targetGroupId,
+  )
+  if (sourceGroupIndex < 0 || targetGroupIndex < 0) return groups
+
+  const sourceGroup = groups[sourceGroupIndex]
+  const movingCollection = sourceGroup.collections[sourceLocation.index]
+  if (!movingCollection) return groups
+
+  const nextGroups = groups.map((group) => ({
+    ...group,
+    collections: [...group.collections],
+  }))
+
+  nextGroups[sourceGroupIndex].collections.splice(sourceLocation.index, 1)
+
+  const boundedTargetIndex = Math.max(
+    0,
+    Math.min(targetIndex, nextGroups[targetGroupIndex].collections.length),
+  )
+  nextGroups[targetGroupIndex].collections.splice(boundedTargetIndex, 0, {
+    ...movingCollection,
+    groupId: targetGroupId,
+  })
+
+  return nextGroups
+}
+
+/**
+ * Reorder root collections within a single group.
+ * @param groups - Source groups
+ * @param groupId - Target group ID
+ * @param fromIndex - Current index
+ * @param toIndex - New index
+ * @returns Updated groups with reordered root collections
+ * @example
+ * reorderRootCollectionInGroup(groups, 'group-0', 0, 2)
+ */
+export function reorderRootCollectionInGroup(
+  groups: Group[],
+  groupId: string,
+  fromIndex: number,
+  toIndex: number,
+): Group[] {
+  const groupIndex = groups.findIndex((group) => group.id === groupId)
+  if (groupIndex < 0) return groups
+
+  const nextGroups = groups.map((group) => ({
+    ...group,
+    collections: [...group.collections],
+  }))
+  const groupCollections = nextGroups[groupIndex].collections
+  if (
+    fromIndex < 0 ||
+    fromIndex >= groupCollections.length ||
+    toIndex < 0 ||
+    toIndex >= groupCollections.length
+  ) {
+    return groups
+  }
+
+  const [movedCollection] = groupCollections.splice(fromIndex, 1)
+  groupCollections.splice(toIndex, 0, movedCollection)
+  return nextGroups
+}
+
+/**
+ * Update one root collection in all groups.
+ * @param groups - Source groups
+ * @param collectionId - Root collection ID to update
+ * @param updater - Transform function applied to the matched collection
+ * @returns Updated groups
+ * @example
+ * updateRootCollection(groups, '100', (c) => ({ ...c, name: 'Renamed' }))
+ */
+export function updateRootCollection(
+  groups: Group[],
+  collectionId: string,
+  updater: (collection: Collection) => Collection,
+): Group[] {
+  return groups.map((group) => ({
+    ...group,
+    collections: group.collections.map((collection) => {
+      if (collection.id !== collectionId) return collection
+      return updater(collection)
+    }),
+  }))
+}
+
+/**
+ * Convert UI groups to API user group payload for `PUT /user`.
+ * @param groups - Current groups with root collection ordering
+ * @returns API payload for user group persistence
+ * @example
+ * toUserGroupPayload(groups) // => [{ title: 'Development', hidden: false, sort: 0, collections: [100, 102] }]
+ */
+export function toUserGroupPayload(groups: Group[]): UserGroupPayload[] {
+  return groups.map((group, index) => ({
+    title: group.name,
+    hidden: false,
+    sort: index,
+    collections: group.collections
+      .map((collection) => parseCollectionId(collection.id))
+      .filter((id): id is number => id !== null),
+  }))
+}

--- a/src/lib/collection-organization.ts
+++ b/src/lib/collection-organization.ts
@@ -43,6 +43,7 @@ export interface RootCollectionLocation {
  * parseCollectionId('abc') // => null
  */
 export function parseCollectionId(collectionId: string): number | null {
+  if (collectionId.trim() === '') return null
   const parsed = Number(collectionId)
   return Number.isFinite(parsed) ? parsed : null
 }

--- a/src/store/api/raindropApi.ts
+++ b/src/store/api/raindropApi.ts
@@ -739,6 +739,7 @@ export type CollectionUpdate = {
   view?: string
   title?: string
   sort?: number
+  color?: string
   public?: boolean
   parent?: {
     $id?: number

--- a/src/utils/favicon.test.ts
+++ b/src/utils/favicon.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveIcon } from './favicon'
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}))
+
+vi.mock('@/lib/axios', () => ({
+  lainAxios: {
+    get: mockGet,
+  },
+}))
+
+describe('resolveIcon', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('returns suggest API icon when available', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        item: {
+          meta: { icon: 'https://react.dev/favicon.ico' },
+        },
+      },
+    })
+
+    await expect(resolveIcon('https://react.dev')).resolves.toBe(
+      'https://react.dev/favicon.ico',
+    )
+  })
+
+  it('falls back to Google favicon when suggest has no icon', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        item: {
+          meta: {},
+        },
+      },
+    })
+
+    await expect(resolveIcon('https://react.dev')).resolves.toBe(
+      'https://www.google.com/s2/favicons?domain=react.dev&sz=64',
+    )
+  })
+
+  it('falls back to Google favicon when suggest request fails', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network'))
+
+    await expect(resolveIcon('https://react.dev')).resolves.toBe(
+      'https://www.google.com/s2/favicons?domain=react.dev&sz=64',
+    )
+  })
+
+  it('returns null for invalid URL input', async () => {
+    await expect(resolveIcon('invalid-url')).resolves.toBeNull()
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,3 +1,4 @@
+import { lainAxios } from '@/lib/axios'
 import type { ContentType } from '@/lib/types'
 
 /**
@@ -21,6 +22,40 @@ export function extractDomain(url: string): string {
 export function getFaviconUrl(domain: string, size = 32): string {
   if (!domain) return ''
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`
+}
+
+/**
+ * Resolve the best available icon URL for a bookmark URL.
+ * Fallback chain:
+ * 1) `/raindrop/suggest?url=...` meta.icon
+ * 2) Google favicon service by domain
+ * 3) null (caller should render domain initial fallback)
+ *
+ * @param url - Bookmark URL
+ * @returns Best icon URL or null when unavailable
+ * @example
+ *   await resolveIcon('https://react.dev')
+ */
+export async function resolveIcon(url: string): Promise<string | null> {
+  const domain = extractDomain(url)
+  if (!domain) return null
+
+  try {
+    const response = await lainAxios.get('/raindrop/suggest', {
+      params: { url },
+    })
+    const suggestedIcon = (
+      response.data as { item?: { meta?: { icon?: string } } }
+    )?.item?.meta?.icon
+    if (typeof suggestedIcon === 'string' && suggestedIcon.length > 0) {
+      return suggestedIcon
+    }
+  } catch {
+    // Intentionally ignored; fall back to Google favicon below.
+  }
+
+  const googleIcon = getFaviconUrl(domain, 64)
+  return googleIcon || null
 }
 
 /**

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -175,6 +175,12 @@ export const handlers = [
     return HttpResponse.json({ result: true, user: mockStore.user })
   }),
 
+  http.put(`${API_BASE}/user`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    const user = mockStore.updateUser(body)
+    return HttpResponse.json({ result: true, user })
+  }),
+
   // --- Filters ---
   http.get(`${API_BASE}/filters/:collectionId`, ({ params }) => {
     const collectionId = Number(params.collectionId)
@@ -203,6 +209,23 @@ export const handlers = [
   }),
 
   // --- Suggest ---
+  http.get(`${API_BASE}/raindrop/suggest`, ({ request }) => {
+    const requestUrl = new URL(request.url)
+    const targetUrl = requestUrl.searchParams.get('url') ?? ''
+    let domain = ''
+    try {
+      domain = new URL(targetUrl).hostname
+    } catch {
+      /* ignore invalid URL */
+    }
+    return HttpResponse.json({
+      result: true,
+      item: {
+        meta: domain ? { icon: `https://${domain}/favicon.ico` } : {},
+      },
+    })
+  }),
+
   http.post(`${API_BASE}/raindrop/suggest`, () => {
     return HttpResponse.json({
       result: true,

--- a/test/mocks/mock-store.ts
+++ b/test/mocks/mock-store.ts
@@ -306,6 +306,21 @@ class MockStore {
     this.tags = this.tags.filter((t) => !tagNames.includes(t._id))
     return true
   }
+
+  // --- User ---
+
+  /**
+   * Update user object with partial payload fields.
+   * @param data - Partial user update payload
+   * @returns Updated user object
+   */
+  updateUser(data: Record<string, unknown>): MockUser {
+    this.user = {
+      ...this.user,
+      ...data,
+    } as MockUser
+    return this.user
+  }
 }
 
 export const mockStore = new MockStore()


### PR DESCRIPTION
## Summary
- implement F6 sidebar organization with dnd-kit, including intra/inter-group drag-and-drop, inline rename, direct context-menu actions (rename/delete/move/color), drag preview, drop indicator, and optimistic rollback behavior
- persist group ordering/membership through `PUT /user` via new collection-organization helpers and CRUD wiring in the app layer
- implement F4 icon assignment flow with `resolveIcon(url)` fallback chain (suggest API -> Google favicon -> letter fallback), and add comprehensive unit + E2E coverage for F4/F6 scenarios

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm knip`
- [x] `pnpm test:e2e`
- [x] `pnpm coverage:e2e-spec`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サイドバーでコレクションのドラッグ＆ドロップ（グループ間移動・並び替え）を実装
  * ブックマーク追加時にURLから自動でアイコンを取得してプレビュー表示
  * ドラッグ時プレビュー／挿入インジケーターを表示

* **改善**
  * コレクションのインライン編集（名前変更）、色変更、コンテキストメニュー操作を追加
  * アイコン解決のフォールバックと読み込み中のUI応答性を向上
  * 楽観的更新と失敗時のロールバック挙動を導入

* **テスト**
  * 自動アイコン取得、DnD、コレクション操作に関するE2E・ユニットテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->