### PR TITLE
feat(p5): wire modifier-key keyboard shortcuts + settings dialog

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain security (added 2026-04-22)
+minimum-release-age=10080
+minimum-release-age-exclude=next,react,react-dom,@types/react,@types/react-dom,typescript,vite,vitest,@vitejs/plugin-react,eslint,prettier,tailwindcss,@tanstack/react-query,zod,react-hook-form,eslint-config-ts-prefixer,@laststance/redux-storage-middleware,@laststance/react-next-eslint-plugin
+verify-store-integrity=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# Supply-chain security (added 2026-04-22)
-minimum-release-age=10080
-minimum-release-age-exclude=next,react,react-dom,@types/react,@types/react-dom,typescript,vite,vitest,@vitejs/plugin-react,eslint,prettier,tailwindcss,@tanstack/react-query,zod,react-hook-form,eslint-config-ts-prefixer,@laststance/redux-storage-middleware,@laststance/react-next-eslint-plugin
-verify-store-integrity=true

--- a/e2e/specs/keyboard.spec.ts
+++ b/e2e/specs/keyboard.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../electron'
+
+/**
+ * Keyboard shortcut E2E tests for PR1 modifier-key shortcuts.
+ * Verifies that global keyboard shortcuts trigger the correct UI actions
+ * when wired through useKeyboardShortcuts hook.
+ *
+ * Uses synthetic KeyboardEvent dispatch via page.evaluate() to avoid
+ * Playwright-Electron key mapping issues with certain modifier combos.
+ */
+
+/** Wait for the main app to fully render (breadcrumb visible = data loaded). */
+async function waitForApp(page: import('@playwright/test').Page) {
+  await expect(
+    page.locator('[data-slot="breadcrumb-page"]', {
+      hasText: 'All Bookmarks',
+    }),
+  ).toBeVisible({ timeout: 10_000 })
+}
+
+/**
+ * Dispatch a synthetic keyboard event on the window.
+ * Bypasses Playwright's keyboard API which can have issues with certain
+ * modifier+key combinations in Electron.
+ */
+async function pressShortcut(
+  page: import('@playwright/test').Page,
+  opts: {
+    key: string
+    metaKey?: boolean
+    shiftKey?: boolean
+    altKey?: boolean
+    ctrlKey?: boolean
+  },
+) {
+  await page.evaluate((o) => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: o.key,
+        metaKey: o.metaKey ?? false,
+        shiftKey: o.shiftKey ?? false,
+        altKey: o.altKey ?? false,
+        ctrlKey: o.ctrlKey ?? false,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+  }, opts)
+}
+
+test.describe('Keyboard Shortcuts', () => {
+  // @spec:KB.1 - CmdK opens search palette
+  test('Cmd+K opens global search palette', async ({ page }) => {
+    await waitForApp(page)
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByText('Search bookmarks')).toBeVisible()
+  })
+
+  // @spec:KB.2 - CmdN opens add bookmark dialog
+  test('Cmd+N opens add bookmark dialog', async ({ page }) => {
+    await waitForApp(page)
+    await pressShortcut(page, { key: 'n', metaKey: true })
+    await expect(
+      page.getByRole('heading', { name: 'Add Bookmark', level: 2 }),
+    ).toBeVisible()
+  })
+
+  // @spec:KB.3 - CmdShiftN opens new collection dialog
+  test('Cmd+Shift+N opens new collection dialog', async ({ page }) => {
+    await waitForApp(page)
+    await page.keyboard.press('Meta+Shift+n')
+    await expect(
+      page.getByRole('heading', { name: /collection/i }),
+    ).toBeVisible()
+  })
+
+  // @spec:KB.4 - Cmd1 switches to grid view
+  test('Cmd+1 switches to grid view', async ({ page }) => {
+    await waitForApp(page)
+    await page.keyboard.press('Meta+1')
+    // Grid view renders cards in a grid layout
+    await expect(page.locator('[data-testid="grid-view"]')).toBeVisible()
+  })
+
+  // @spec:KB.5 - Cmd2 switches to list view
+  test('Cmd+2 switches to list view', async ({ page }) => {
+    await waitForApp(page)
+    // First switch away from list (default)
+    await page.keyboard.press('Meta+1')
+    await expect(page.locator('[data-testid="grid-view"]')).toBeVisible()
+    // Then back to list
+    await page.keyboard.press('Meta+2')
+    await expect(page.locator('[data-testid="list-view"]')).toBeVisible()
+  })
+
+  // @spec:KB.8 - CmdComma opens settings
+  test('Cmd+, opens settings dialog', async ({ page }) => {
+    await waitForApp(page)
+    await pressShortcut(page, { key: ',', metaKey: true })
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+  })
+
+  // @spec:KB.16 - CmdShiftK opens shortcut settings
+  test('Cmd+Shift+K opens settings on shortcuts tab', async ({ page }) => {
+    await waitForApp(page)
+    await pressShortcut(page, { key: 'k', metaKey: true, shiftKey: true })
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+    await expect(
+      page.getByRole('tab', { name: 'Keyboard Shortcuts', selected: true }),
+    ).toBeVisible()
+  })
+
+  // @spec:KB.10 - CmdA selects all bookmarks
+  test('Cmd+A selects all bookmarks in view', async ({ page }) => {
+    await waitForApp(page)
+    await page.keyboard.press('Meta+a')
+    // When all selected, the bulk action bar should appear
+    await expect(page.getByText(/selected/i)).toBeVisible()
+  })
+
+  // @spec:KB.20 - CmdShiftT opens tag management
+  test('Cmd+Shift+T opens tag management', async ({ page }) => {
+    await waitForApp(page)
+    await pressShortcut(page, { key: 't', metaKey: true, shiftKey: true })
+    await expect(page.getByRole('heading', { name: /tag/i })).toBeVisible()
+  })
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,25 @@
+packages:
+  - .
+
+# Supply-chain security (migrated from .npmrc 2026-05-07)
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - next
+  - react
+  - react-dom
+  - '@types/react'
+  - '@types/react-dom'
+  - typescript
+  - vite
+  - vitest
+  - '@vitejs/plugin-react'
+  - eslint
+  - prettier
+  - tailwindcss
+  - '@tanstack/react-query'
+  - zod
+  - react-hook-form
+  - eslint-config-ts-prefixer
+  - '@laststance/redux-storage-middleware'
+  - '@laststance/react-next-eslint-plugin'
+verifyStoreIntegrity: true

--- a/src/components/main-app.tsx
+++ b/src/components/main-app.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 
 import { AddBookmarkDialog } from '@/components/raindrop/add-bookmark-dialog'
 import { CollectionDialog } from '@/components/raindrop/collection-dialog'
@@ -8,10 +8,12 @@ import { LeftSidebar } from '@/components/raindrop/left-sidebar'
 import { MainContent } from '@/components/raindrop/main-content'
 import { MergeDialog } from '@/components/raindrop/merge-dialog'
 import { RightDetailPanel } from '@/components/raindrop/right-detail-panel'
+import { SettingsDialog } from '@/components/raindrop/settings-dialog'
 import { TagManagement } from '@/components/raindrop/tag-management'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 import { useCollectionsCrud } from '@/hooks/useCollectionsCrud'
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useRaindropsCrud } from '@/hooks/useRaindropsCrud'
 import { useSidebarData } from '@/hooks/useSidebarData'
 import { useTagsCrud } from '@/hooks/useTagsCrud'
@@ -24,6 +26,7 @@ import type {
   SearchMode,
   SearchScope,
   SortOption,
+  ViewMode,
 } from '@/lib/types'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
@@ -31,11 +34,13 @@ import {
   closeCollectionDialog,
   closeGroupDialog,
   closeMergeDialog,
+  closeSettings,
   closeTagManagement,
   openAddBookmark,
   openCollectionDialog,
   openGroupDialog,
   openMergeDialog,
+  openSettings,
   openTagManagement,
 } from '@/store/slices/dialogSlice'
 import {
@@ -46,9 +51,12 @@ import {
 } from '@/store/slices/searchSlice'
 import {
   clearSelection,
+  getEffectiveViewMode,
+  selectAllRaindrops,
   setDetailPanelOpen,
   setSelectedCollectionId,
   setSelectedRaindropIds,
+  setViewMode,
 } from '@/store/slices/uiSlice'
 
 /**
@@ -78,6 +86,12 @@ export const MainApp = React.memo(function MainApp() {
   const isGroupDialogOpen = useAppSelector((s) => s.dialog.groupDialog.open)
   const isTagManagementOpen = useAppSelector((s) => s.dialog.tagManagement.open)
   const isMergeDialogOpen = useAppSelector((s) => s.dialog.mergeDialog.open)
+  const isSettingsOpen = useAppSelector((s) => s.dialog.settings.open)
+  const settingsTab = useAppSelector((s) => s.dialog.settings.tab)
+  const effectiveViewMode = useAppSelector(getEffectiveViewMode)
+
+  // --- Refs ---
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // --- Local State ---
   const [selectedRaindrop, setSelectedRaindrop] = useState<
@@ -426,6 +440,78 @@ export const MainApp = React.memo(function MainApp() {
     [dispatch],
   )
 
+  // --- View Mode ---
+  const handleViewModeChange = useCallback(
+    (mode: ViewMode) => dispatch(setViewMode(mode)),
+    [dispatch],
+  )
+
+  // --- Settings Dialog ---
+  const handleSettingsOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) dispatch(closeSettings())
+    },
+    [dispatch],
+  )
+
+  // --- Keyboard Shortcuts ---
+  useKeyboardShortcuts(
+    useMemo(
+      () => ({
+        search: () => dispatch(setSearchOpen(!isSearchOpen)),
+        newBookmark: handleAddBookmark,
+        newCollection: handleAddCollection,
+        viewGrid: () => dispatch(setViewMode('grid')),
+        viewList: () => dispatch(setViewMode('list')),
+        viewTable: () => dispatch(setViewMode('table')),
+        viewDirectory: () => dispatch(setViewMode('directory')),
+        settings: () => dispatch(openSettings()),
+        editShortcuts: () => dispatch(openSettings({ tab: 'shortcuts' })),
+        delete: () => {
+          const ids =
+            selectedRaindropIds.length > 0
+              ? selectedRaindropIds
+              : selectedRaindrop
+                ? [selectedRaindrop.id]
+                : []
+          if (ids.length > 0) batchDeleteRaindrops(ids)
+        },
+        selectAll: () => {
+          const allIds = raindrops.map((r) => r.id)
+          dispatch(selectAllRaindrops(allIds))
+        },
+        searchInView: () => searchInputRef.current?.focus(),
+        searchGlobal: () => {
+          dispatch(setSearchMode('global'))
+          dispatch(setSearchOpen(true))
+        },
+        toggleImportant: () => {
+          const targetId =
+            selectedRaindropIds.length === 1
+              ? selectedRaindropIds[0]
+              : selectedRaindrop?.id
+          if (!targetId) return
+          const target = raindrops.find((r) => r.id === targetId)
+          if (target)
+            updateRaindrop(targetId, { isImportant: !target.isImportant })
+        },
+        manageTags: handleManageTags,
+      }),
+      [
+        dispatch,
+        isSearchOpen,
+        handleAddBookmark,
+        handleAddCollection,
+        selectedRaindropIds,
+        selectedRaindrop,
+        batchDeleteRaindrops,
+        raindrops,
+        updateRaindrop,
+        handleManageTags,
+      ],
+    ),
+  )
+
   // --- Dialog Close Handlers ---
   const handleAddBookmarkOpenChange = useCallback(
     (open: boolean) => {
@@ -524,6 +610,9 @@ export const MainApp = React.memo(function MainApp() {
             onBatchMove={handleBatchMove}
             onBatchAddTag={handleBatchAddTag}
             onBatchDelete={handleBatchDelete}
+            viewMode={effectiveViewMode}
+            onViewModeChange={handleViewModeChange}
+            searchInputRef={searchInputRef}
           />
         </SidebarInset>
 
@@ -588,6 +677,12 @@ export const MainApp = React.memo(function MainApp() {
           onOpenChange={handleMergeDialogOpenChange}
           collections={groups.flatMap((g) => g.collections)}
           onConfirm={handleMergeCollections}
+        />
+
+        <SettingsDialog
+          open={isSettingsOpen}
+          onOpenChange={handleSettingsOpenChange}
+          defaultTab={settingsTab}
         />
       </div>
       <Toaster />

--- a/src/components/raindrop/global-search-command.tsx
+++ b/src/components/raindrop/global-search-command.tsx
@@ -10,7 +10,7 @@ import {
   X,
   ArrowRight,
 } from 'lucide-react'
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { FaviconIcon } from '@/components/raindrop/favicon-icon'
 import { Badge } from '@/components/ui/badge'
@@ -238,27 +238,6 @@ const SEARCH_SCOPE_LABELS: Record<SearchScope, string> = {
 }
 
 /**
- * Register a global Cmd+K keyboard shortcut to toggle the search palette.
- * @param open - Whether the palette is currently open
- * @param onOpenChange - Callback to toggle palette visibility
- */
-function useGlobalSearchShortcut(
-  open: boolean,
-  onOpenChange: (open: boolean) => void,
-) {
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault()
-        onOpenChange(!open)
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [open, onOpenChange])
-}
-
-/**
  * Global search command palette triggered by Cmd+K.
  * Searches across all raindrops with scope filtering and recent searches.
  *
@@ -295,8 +274,6 @@ const GlobalSearchCommand = React.memo(function GlobalSearchCommand({
   const searchScope = useAppSelector((s) => s.search.scope)
   const searchMode = useAppSelector((s) => s.search.mode)
   const recentSearches = useAppSelector((s) => s.search.recentSearches)
-
-  useGlobalSearchShortcut(open, onOpenChange)
 
   const searchResults = useMemo(() => {
     if (!searchQuery.trim()) return []

--- a/src/components/raindrop/main-content.tsx
+++ b/src/components/raindrop/main-content.tsx
@@ -190,6 +190,12 @@ interface MainContentProps {
   onBatchAddTag?: (ids: string[], tags: string[]) => Promise<void>
   /** Batch delete selected raindrops */
   onBatchDelete?: (ids: string[]) => Promise<void>
+  /** Current view mode from Redux (effective: per-collection override > global) */
+  viewMode: ViewMode
+  /** Callback when view mode changes */
+  onViewModeChange: (mode: ViewMode) => void
+  /** Ref to expose the search input for programmatic focus (Cmd+F) */
+  searchInputRef?: React.RefObject<HTMLInputElement | null>
 }
 
 /**
@@ -357,11 +363,13 @@ const MainContent = React.memo(function MainContent({
   onBatchMove,
   onBatchAddTag,
   onBatchDelete,
+  viewMode,
+  onViewModeChange,
+  searchInputRef,
 }: MainContentProps) {
   // Reserved for bulk action "Move to..." functionality
   void _groups
   void _collections
-  const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [isAdvancedSearchOpen, setIsAdvancedSearchOpen] = useState(false)
   const currentCollectionName =
     breadcrumbs[breadcrumbs.length - 1] ?? 'Collection'
@@ -377,9 +385,12 @@ const MainContent = React.memo(function MainContent({
     () => setIsAdvancedSearchOpen((prev) => !prev),
     [],
   )
-  const handleViewModeChange = useCallback((val: string) => {
-    if (val) setViewMode(val as ViewMode)
-  }, [])
+  const handleViewModeChange = useCallback(
+    (val: string) => {
+      if (val) onViewModeChange(val as ViewMode)
+    },
+    [onViewModeChange],
+  )
   const handleSortChange = useCallback(
     (val: string) => onSortChange(val as SortOption),
     [onSortChange],
@@ -556,7 +567,8 @@ const MainContent = React.memo(function MainContent({
           <div className="relative max-w-md flex-1">
             <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
             <Input
-              placeholder="Search bookmarks... (Cmd+K)"
+              ref={searchInputRef}
+              placeholder="Search bookmarks... (⌘K)"
               value={searchQuery}
               onChange={handleSearchQueryChange}
               className="h-8 pr-8 pl-8 text-sm"
@@ -793,7 +805,10 @@ const MainContent = React.memo(function MainContent({
           </div>
         ) : viewMode === 'grid' ? (
           /* Grid View */
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 p-4">
+          <div
+            data-testid="grid-view"
+            className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 p-4"
+          >
             {filteredRaindrops.map((raindrop) => (
               <RaindropCardWrapper
                 key={raindrop.id}
@@ -811,7 +826,7 @@ const MainContent = React.memo(function MainContent({
           </div>
         ) : (
           /* List View (default) */
-          <div className="divide-y">
+          <div data-testid="list-view" className="divide-y">
             {filteredRaindrops.map((raindrop) => (
               <RaindropListItemWrapper
                 key={raindrop.id}

--- a/src/components/raindrop/settings-dialog.tsx
+++ b/src/components/raindrop/settings-dialog.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { formatShortcut } from '@/lib/shortcut-utils'
+import type { ViewMode } from '@/lib/types'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import {
+  SHORTCUT_DEFINITIONS,
+  setDefaultViewMode,
+  setTheme,
+} from '@/store/slices/settingsSlice'
+import type { ShortcutCategory } from '@/store/slices/settingsSlice'
+
+interface SettingsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  defaultTab?: string
+}
+
+const CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  navigation: 'Navigation',
+  editing: 'Editing',
+  view: 'View',
+  system: 'System',
+}
+
+const CATEGORY_ORDER: ShortcutCategory[] = [
+  'navigation',
+  'editing',
+  'view',
+  'system',
+]
+
+/**
+ * Settings dialog with General and Keyboard Shortcuts tabs.
+ * Shortcuts tab is read-only in PR1; editing ships in PR2.
+ *
+ * @example
+ *   <SettingsDialog open={isOpen} onOpenChange={setIsOpen} defaultTab="shortcuts" />
+ */
+export const SettingsDialog = React.memo(function SettingsDialog({
+  open,
+  onOpenChange,
+  defaultTab,
+}: SettingsDialogProps) {
+  const dispatch = useAppDispatch()
+  const shortcuts = useAppSelector((s) => s.settings.shortcuts)
+  const theme = useAppSelector((s) => s.settings.theme)
+  const defaultViewMode = useAppSelector((s) => s.settings.defaultViewMode)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>Customize your Lain experience.</DialogDescription>
+        </DialogHeader>
+        <Tabs defaultValue={defaultTab ?? 'general'}>
+          <TabsList className="w-full">
+            <TabsTrigger value="general" className="flex-1">
+              General
+            </TabsTrigger>
+            <TabsTrigger value="shortcuts" className="flex-1">
+              Keyboard Shortcuts
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="general" className="space-y-4 pt-4">
+            {/* Theme */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Theme</p>
+                <p className="text-muted-foreground text-xs">
+                  Choose your preferred color scheme.
+                </p>
+              </div>
+              <select
+                value={theme}
+                onChange={(e) =>
+                  dispatch(
+                    setTheme(e.target.value as 'light' | 'dark' | 'system'),
+                  )
+                }
+                className="bg-background border-input h-8 rounded-md border px-2 text-sm"
+              >
+                <option value="system">System</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </div>
+
+            {/* Default View Mode */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Default View</p>
+                <p className="text-muted-foreground text-xs">
+                  Default view mode for collections.
+                </p>
+              </div>
+              <select
+                value={defaultViewMode}
+                onChange={(e) =>
+                  dispatch(setDefaultViewMode(e.target.value as ViewMode))
+                }
+                className="bg-background border-input h-8 rounded-md border px-2 text-sm"
+              >
+                <option value="list">List</option>
+                <option value="grid">Grid</option>
+                <option value="table">Table</option>
+                <option value="directory">Directory</option>
+              </select>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="shortcuts" className="pt-4">
+            <div className="max-h-[400px] overflow-y-auto">
+              {CATEGORY_ORDER.map((category) => {
+                const defs = SHORTCUT_DEFINITIONS.filter(
+                  (d) => d.category === category,
+                )
+                if (defs.length === 0) return null
+                return (
+                  <div key={category} className="mb-4">
+                    <h4 className="text-muted-foreground mb-2 text-xs font-semibold tracking-wider uppercase">
+                      {CATEGORY_LABELS[category]}
+                    </h4>
+                    <div className="space-y-1">
+                      {defs.map((def) => {
+                        const binding = shortcuts[def.actionId]
+                        return (
+                          <div
+                            key={def.actionId}
+                            className="flex items-center justify-between rounded-md px-2 py-1.5"
+                          >
+                            <span className="text-sm">{def.label}</span>
+                            {binding && (
+                              <kbd className="bg-muted text-muted-foreground rounded border px-1.5 py-0.5 font-mono text-xs">
+                                {formatShortcut(binding)}
+                              </kbd>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+})

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,132 @@
+import { act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { renderHookWithProviders } from '@test/render-with-providers'
+
+import { useKeyboardShortcuts } from './useKeyboardShortcuts'
+
+function fireKeydown(
+  key: string,
+  modifiers: Partial<{
+    metaKey: boolean
+    shiftKey: boolean
+    altKey: boolean
+    ctrlKey: boolean
+  }> = {},
+  target?: EventTarget,
+) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  })
+  if (target) {
+    Object.defineProperty(event, 'target', { value: target })
+  }
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('useKeyboardShortcuts', () => {
+  it('fires handler for Cmd+N', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ newBookmark: handler }),
+    )
+
+    act(() => {
+      fireKeydown('n', { metaKey: true })
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('fires handler for Cmd+Shift+K', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ editShortcuts: handler }),
+    )
+
+    act(() => {
+      fireKeydown('k', { metaKey: true, shiftKey: true })
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT fire for non-modifier keys (ArrowDown)', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ navigateDown: handler }),
+    )
+
+    act(() => {
+      fireKeydown('ArrowDown')
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('suppresses selectAll when focus is in an input', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() => useKeyboardShortcuts({ selectAll: handler }))
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    act(() => {
+      fireKeydown('a', { metaKey: true }, input)
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+    document.body.removeChild(input)
+  })
+
+  it('suppresses searchInView when focus is in an input', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ searchInView: handler }),
+    )
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    act(() => {
+      fireKeydown('f', { metaKey: true }, input)
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+    document.body.removeChild(input)
+  })
+
+  it('still fires Cmd+N when focus is in an input (not a native text shortcut)', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ newBookmark: handler }),
+    )
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    act(() => {
+      fireKeydown('n', { metaKey: true }, input)
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+    document.body.removeChild(input)
+  })
+
+  it('does not fire handler for unregistered actions', () => {
+    const handler = vi.fn()
+    renderHookWithProviders(() =>
+      useKeyboardShortcuts({ newBookmark: handler }),
+    )
+
+    act(() => {
+      fireKeydown('x', { metaKey: true })
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react'
+
+import { isEditableTarget, matchesBinding } from '@/lib/shortcut-utils'
+import { useAppSelector } from '@/store/hooks'
+import type { ShortcutActionId } from '@/store/slices/settingsSlice'
+
+/**
+ * Action IDs whose default bindings conflict with native text editing in inputs.
+ * These shortcuts are suppressed when focus is in an editable target.
+ * - selectAll (Cmd+A): selects all text in input
+ * - searchInView (Cmd+F): browser find-in-page
+ * - delete (Cmd+Backspace): deletes line in input
+ */
+const NATIVE_TEXT_SHORTCUTS: ReadonlySet<string> = new Set<ShortcutActionId>([
+  'selectAll',
+  'searchInView',
+  'delete',
+])
+
+/**
+ * Global keyboard shortcut hook that reads bindings from Redux settingsSlice.
+ * Only handles modifier-key shortcuts (Cmd/Ctrl) — navigation keys (arrows,
+ * Enter, Space) are handled view-locally in PR2.
+ *
+ * Escape is NOT handled here — Radix dialogs manage their own Escape.
+ *
+ * @param handlers - Map of action IDs to handler functions
+ * @example
+ *   useKeyboardShortcuts({
+ *     search: () => dispatch(toggleSearch()),
+ *     newBookmark: () => dispatch(openAddBookmark()),
+ *     viewGrid: () => dispatch(setViewMode('grid')),
+ *   })
+ */
+export function useKeyboardShortcuts(
+  handlers: Partial<Record<ShortcutActionId, () => void>>,
+): void {
+  const shortcuts = useAppSelector((state) => state.settings.shortcuts)
+  const handlersRef = useRef(handlers)
+  const shortcutsRef = useRef(shortcuts)
+
+  // Sync refs in effect to satisfy React Compiler (no ref writes during render)
+  useEffect(() => {
+    handlersRef.current = handlers
+    shortcutsRef.current = shortcuts
+  })
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const currentShortcuts = shortcutsRef.current
+      const currentHandlers = handlersRef.current
+
+      for (const [actionId, binding] of Object.entries(currentShortcuts)) {
+        if (!matchesBinding(e, binding)) continue
+
+        // Only handle modifier shortcuts (Cmd/Ctrl) + Escape-display-only
+        if (!binding.meta && !binding.ctrl) continue
+
+        // Suppress shortcuts that conflict with native text editing in inputs
+        if (isEditableTarget(e.target) && NATIVE_TEXT_SHORTCUTS.has(actionId)) {
+          continue
+        }
+
+        const handler = currentHandlers[actionId as ShortcutActionId]
+        if (handler) {
+          e.preventDefault()
+          handler()
+          return
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+}

--- a/src/lib/shortcut-utils.test.ts
+++ b/src/lib/shortcut-utils.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ShortcutBinding, ShortcutMap } from '@/store/slices/settingsSlice'
+
+import {
+  findConflict,
+  formatShortcut,
+  isEditableTarget,
+  matchesBinding,
+} from './shortcut-utils'
+
+// Helper to create a minimal KeyboardEvent-like object
+function makeEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: '',
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    ...overrides,
+  } as KeyboardEvent
+}
+
+describe('matchesBinding', () => {
+  const cmdN: ShortcutBinding = {
+    key: 'n',
+    meta: true,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  }
+
+  it('matches Cmd+N', () => {
+    const event = makeEvent({ key: 'n', metaKey: true })
+    expect(matchesBinding(event, cmdN)).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    const event = makeEvent({ key: 'N', metaKey: true })
+    expect(matchesBinding(event, cmdN)).toBe(true)
+  })
+
+  it('rejects when meta is not pressed', () => {
+    const event = makeEvent({ key: 'n', metaKey: false })
+    expect(matchesBinding(event, cmdN)).toBe(false)
+  })
+
+  it('rejects when shift is pressed but not expected', () => {
+    const event = makeEvent({ key: 'n', metaKey: true, shiftKey: true })
+    expect(matchesBinding(event, cmdN)).toBe(false)
+  })
+
+  it('matches Cmd+Shift+K', () => {
+    const cmdShiftK: ShortcutBinding = {
+      key: 'k',
+      meta: true,
+      shift: true,
+      alt: false,
+      ctrl: false,
+    }
+    const event = makeEvent({ key: 'k', metaKey: true, shiftKey: true })
+    expect(matchesBinding(event, cmdShiftK)).toBe(true)
+  })
+
+  it('matches Escape (no modifiers)', () => {
+    const esc: ShortcutBinding = {
+      key: 'Escape',
+      meta: false,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    const event = makeEvent({ key: 'Escape' })
+    expect(matchesBinding(event, esc)).toBe(true)
+  })
+
+  it('rejects wrong key', () => {
+    const event = makeEvent({ key: 'x', metaKey: true })
+    expect(matchesBinding(event, cmdN)).toBe(false)
+  })
+})
+
+describe('isEditableTarget', () => {
+  it('returns true for INPUT', () => {
+    const input = document.createElement('input')
+    expect(isEditableTarget(input)).toBe(true)
+  })
+
+  it('returns true for TEXTAREA', () => {
+    const textarea = document.createElement('textarea')
+    expect(isEditableTarget(textarea)).toBe(true)
+  })
+
+  it('returns true for contenteditable', () => {
+    const div = document.createElement('div')
+    div.contentEditable = 'true'
+    expect(isEditableTarget(div)).toBe(true)
+  })
+
+  it('returns false for regular div', () => {
+    const div = document.createElement('div')
+    expect(isEditableTarget(div)).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isEditableTarget(null)).toBe(false)
+  })
+})
+
+describe('formatShortcut', () => {
+  it('formats Cmd+N', () => {
+    const binding: ShortcutBinding = {
+      key: 'n',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('\u2318N')
+  })
+
+  it('formats Cmd+Shift+K', () => {
+    const binding: ShortcutBinding = {
+      key: 'k',
+      meta: true,
+      shift: true,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('\u21E7\u2318K')
+  })
+
+  it('formats Escape', () => {
+    const binding: ShortcutBinding = {
+      key: 'Escape',
+      meta: false,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('Esc')
+  })
+
+  it('formats Cmd+Backspace', () => {
+    const binding: ShortcutBinding = {
+      key: 'Backspace',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('\u2318\u232B')
+  })
+
+  it('formats Cmd+, (comma)', () => {
+    const binding: ShortcutBinding = {
+      key: ',',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('\u2318,')
+  })
+
+  it('formats Cmd+1', () => {
+    const binding: ShortcutBinding = {
+      key: '1',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(formatShortcut(binding)).toBe('\u23181')
+  })
+})
+
+describe('findConflict', () => {
+  const map: ShortcutMap = {
+    search: { key: 'k', meta: true, shift: false, alt: false, ctrl: false },
+    newBookmark: {
+      key: 'n',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    },
+  }
+
+  it('finds a conflict', () => {
+    const binding: ShortcutBinding = {
+      key: 'k',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(findConflict(map, binding)).toBe('search')
+  })
+
+  it('excludes specified action', () => {
+    const binding: ShortcutBinding = {
+      key: 'k',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(findConflict(map, binding, 'search')).toBeNull()
+  })
+
+  it('returns null for no conflict', () => {
+    const binding: ShortcutBinding = {
+      key: 'x',
+      meta: true,
+      shift: false,
+      alt: false,
+      ctrl: false,
+    }
+    expect(findConflict(map, binding)).toBeNull()
+  })
+})

--- a/src/lib/shortcut-utils.ts
+++ b/src/lib/shortcut-utils.ts
@@ -1,0 +1,114 @@
+import type { ShortcutBinding, ShortcutMap } from '@/store/slices/settingsSlice'
+
+/**
+ * Check if a keyboard event matches a shortcut binding.
+ *
+ * @param event - The keyboard event to check
+ * @param binding - The shortcut binding to match against
+ * @returns true if the event matches the binding
+ * @example
+ *   matchesBinding(event, { key: 'n', meta: true, shift: false, alt: false, ctrl: false })
+ *   // => true when user presses Cmd+N
+ */
+export function matchesBinding(
+  event: KeyboardEvent,
+  binding: ShortcutBinding,
+): boolean {
+  return (
+    event.key.toLowerCase() === binding.key.toLowerCase() &&
+    event.metaKey === binding.meta &&
+    event.shiftKey === binding.shift &&
+    event.altKey === binding.alt &&
+    event.ctrlKey === binding.ctrl
+  )
+}
+
+/**
+ * Check if the event target is an editable element (input, textarea, contenteditable).
+ *
+ * @param target - The event target to check
+ * @returns true if the target is an editable element
+ * @example
+ *   isEditableTarget(document.querySelector('input'))  // => true
+ *   isEditableTarget(document.querySelector('div'))     // => false
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false
+  const tagName = target.tagName
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA') return true
+  if (target.isContentEditable) return true
+  return false
+}
+
+const SYMBOL_MAP: Record<string, string> = {
+  meta: '\u2318',
+  shift: '\u21E7',
+  alt: '\u2325',
+  ctrl: '\u2303',
+  Backspace: '\u232B',
+  Escape: 'Esc',
+  ArrowUp: '\u2191',
+  ArrowDown: '\u2193',
+  ArrowLeft: '\u2190',
+  ArrowRight: '\u2192',
+  Enter: '\u21A9',
+  ' ': 'Space',
+  ',': ',',
+}
+
+/**
+ * Format a shortcut binding into a human-readable string using macOS symbols.
+ *
+ * @param binding - The shortcut binding to format
+ * @returns Formatted string like "⌘⇧K" or "⌘N"
+ * @example
+ *   formatShortcut({ key: 'k', meta: true, shift: true, alt: false, ctrl: false })
+ *   // => "⌘⇧K"
+ *   formatShortcut({ key: 'Escape', meta: false, shift: false, alt: false, ctrl: false })
+ *   // => "Esc"
+ */
+export function formatShortcut(binding: ShortcutBinding): string {
+  const parts: string[] = []
+  if (binding.ctrl) parts.push(SYMBOL_MAP.ctrl)
+  if (binding.alt) parts.push(SYMBOL_MAP.alt)
+  if (binding.shift) parts.push(SYMBOL_MAP.shift)
+  if (binding.meta) parts.push(SYMBOL_MAP.meta)
+
+  const keyDisplay = SYMBOL_MAP[binding.key] ?? binding.key.toUpperCase()
+  parts.push(keyDisplay)
+
+  return parts.join('')
+}
+
+/**
+ * Find a conflicting shortcut action for a given binding.
+ *
+ * @param map - The current shortcut map
+ * @param binding - The binding to check for conflicts
+ * @param excludeId - Optional action ID to exclude (the action being edited)
+ * @returns The conflicting action ID, or null if no conflict
+ * @example
+ *   findConflict(shortcuts, { key: 'n', meta: true, ... }, 'newBookmark')
+ *   // => null (excluded)
+ *   findConflict(shortcuts, { key: 'n', meta: true, ... })
+ *   // => 'newBookmark'
+ */
+export function findConflict(
+  map: ShortcutMap,
+  binding: ShortcutBinding,
+  excludeId?: string,
+): string | null {
+  for (const [actionId, existing] of Object.entries(map)) {
+    if (actionId === excludeId) continue
+    if (
+      existing.key.toLowerCase() === binding.key.toLowerCase() &&
+      existing.meta === binding.meta &&
+      existing.shift === binding.shift &&
+      existing.alt === binding.alt &&
+      existing.ctrl === binding.ctrl
+    ) {
+      return actionId
+    }
+  }
+  return null
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ import {
 import { authSlice } from './slices/authSlice'
 import { dialogSlice } from './slices/dialogSlice'
 import { searchSlice } from './slices/searchSlice'
-import { settingsSlice } from './slices/settingsSlice'
+import { hydrateShortcuts, settingsSlice } from './slices/settingsSlice'
 import { uiSlice } from './slices/uiSlice'
 
 /**
@@ -68,6 +68,18 @@ export const store = configureStore({
 // Initialize side effects after store creation (synchronous for theme, async for auth)
 setupThemeListeners(store)
 setupAuthListeners(store)
+
+// Merge persisted shortcuts with defaults so new shortcuts from code updates appear.
+// Must run AFTER storage middleware finishes hydrating from localStorage,
+// otherwise HYDRATE_COMPLETE overwrites our merged map via microtask.
+storageApi.onFinishHydration(() => {
+  store.dispatch(hydrateShortcuts())
+})
+
+// Expose store for E2E testing (allows verifying Redux state in Playwright tests)
+if (typeof window !== 'undefined') {
+  ;(window as unknown as Record<string, unknown>).__STORE__ = store
+}
 
 export type AppDispatch = typeof store.dispatch
 export { storageApi }

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -23,7 +23,93 @@ export interface ShortcutBinding {
   ctrl: boolean
 }
 
+/**
+ * All 20 keyboard shortcut action IDs from SPEC Section 6.1.
+ * PR1 wires modifier-key shortcuts; PR2 wires navigation keys.
+ */
+export type ShortcutActionId =
+  | 'search'
+  | 'newBookmark'
+  | 'newCollection'
+  | 'viewGrid'
+  | 'viewList'
+  | 'viewTable'
+  | 'viewDirectory'
+  | 'settings'
+  | 'delete'
+  | 'selectAll'
+  | 'navigateUp'
+  | 'navigateDown'
+  | 'openSelected'
+  | 'previewToggle'
+  | 'escape'
+  | 'editShortcuts'
+  | 'searchInView'
+  | 'searchGlobal'
+  | 'toggleImportant'
+  | 'manageTags'
+
 export type ShortcutMap = Record<string, ShortcutBinding>
+
+/**
+ * Shortcut category for grouping in the settings UI.
+ */
+export type ShortcutCategory = 'navigation' | 'editing' | 'view' | 'system'
+
+/**
+ * Metadata for a shortcut action, used by the settings dialog shortcut table.
+ * @example
+ *   SHORTCUT_DEFINITIONS[0]
+ *   // => { actionId: 'search', label: 'Global Search', category: 'navigation' }
+ */
+export interface ShortcutDefinition {
+  actionId: ShortcutActionId
+  label: string
+  category: ShortcutCategory
+}
+
+/**
+ * All 20 shortcut definitions with human-readable labels and categories.
+ * Used by the settings dialog to render the read-only shortcut table.
+ */
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  { actionId: 'search', label: 'Global Search', category: 'navigation' },
+  { actionId: 'searchInView', label: 'Search in View', category: 'navigation' },
+  {
+    actionId: 'searchGlobal',
+    label: 'Search All Collections',
+    category: 'navigation',
+  },
+  { actionId: 'navigateUp', label: 'Move Up', category: 'navigation' },
+  { actionId: 'navigateDown', label: 'Move Down', category: 'navigation' },
+  { actionId: 'openSelected', label: 'Open Selected', category: 'navigation' },
+  { actionId: 'escape', label: 'Close Panel / Dialog', category: 'navigation' },
+  { actionId: 'newBookmark', label: 'New Bookmark', category: 'editing' },
+  { actionId: 'newCollection', label: 'New Collection', category: 'editing' },
+  { actionId: 'delete', label: 'Delete Selected', category: 'editing' },
+  { actionId: 'selectAll', label: 'Select All', category: 'editing' },
+  {
+    actionId: 'toggleImportant',
+    label: 'Toggle Important',
+    category: 'editing',
+  },
+  { actionId: 'manageTags', label: 'Manage Tags', category: 'editing' },
+  { actionId: 'viewGrid', label: 'Grid View', category: 'view' },
+  { actionId: 'viewList', label: 'List View', category: 'view' },
+  { actionId: 'viewTable', label: 'Table View', category: 'view' },
+  { actionId: 'viewDirectory', label: 'Directory View', category: 'view' },
+  {
+    actionId: 'previewToggle',
+    label: 'Toggle Preview Panel',
+    category: 'view',
+  },
+  { actionId: 'settings', label: 'Settings', category: 'system' },
+  {
+    actionId: 'editShortcuts',
+    label: 'Keyboard Shortcuts',
+    category: 'system',
+  },
+]
 
 /**
  * Settings state for shortcuts, theme, and preferences.
@@ -43,8 +129,10 @@ interface SettingsState {
 
 /**
  * Default keyboard shortcut bindings following macOS conventions.
+ * All 20 shortcuts from SPEC Section 6.1.
  */
 export const DEFAULT_SHORTCUTS: ShortcutMap = {
+  search: { key: 'k', meta: true, shift: false, alt: false, ctrl: false },
   newBookmark: { key: 'n', meta: true, shift: false, alt: false, ctrl: false },
   newCollection: {
     key: 'n',
@@ -63,6 +151,13 @@ export const DEFAULT_SHORTCUTS: ShortcutMap = {
     alt: false,
     ctrl: false,
   },
+  settings: {
+    key: ',',
+    meta: true,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
   delete: {
     key: 'Backspace',
     meta: true,
@@ -71,11 +166,73 @@ export const DEFAULT_SHORTCUTS: ShortcutMap = {
     ctrl: false,
   },
   selectAll: { key: 'a', meta: true, shift: false, alt: false, ctrl: false },
-  search: { key: 'k', meta: true, shift: false, alt: false, ctrl: false },
+  navigateUp: {
+    key: 'ArrowUp',
+    meta: false,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  navigateDown: {
+    key: 'ArrowDown',
+    meta: false,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  openSelected: {
+    key: 'Enter',
+    meta: false,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  previewToggle: {
+    key: ' ',
+    meta: false,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
   escape: {
     key: 'Escape',
     meta: false,
     shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  editShortcuts: {
+    key: 'k',
+    meta: true,
+    shift: true,
+    alt: false,
+    ctrl: false,
+  },
+  searchInView: {
+    key: 'f',
+    meta: true,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  searchGlobal: {
+    key: 'f',
+    meta: true,
+    shift: true,
+    alt: false,
+    ctrl: false,
+  },
+  toggleImportant: {
+    key: 'd',
+    meta: true,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  },
+  manageTags: {
+    key: 't',
+    meta: true,
+    shift: true,
     alt: false,
     ctrl: false,
   },
@@ -86,6 +243,21 @@ const initialState: SettingsState = {
   theme: 'system',
   resolvedTheme: 'light',
   defaultViewMode: 'list',
+}
+
+/**
+ * Merge persisted shortcuts with defaults so new shortcuts added in code
+ * are available without clearing localStorage.
+ * Persisted bindings take precedence over defaults for existing keys.
+ *
+ * @param persisted - ShortcutMap from localStorage (may be missing new keys)
+ * @returns Complete ShortcutMap with all 20 shortcuts
+ * @example
+ *   migrateShortcuts({ search: { key: 'k', ... } })
+ *   // => { search: { key: 'k', ... }, settings: { key: ',', ... }, ... } (all 20)
+ */
+export function migrateShortcuts(persisted: ShortcutMap): ShortcutMap {
+  return { ...DEFAULT_SHORTCUTS, ...persisted }
 }
 
 export const settingsSlice = createSlice({
@@ -113,6 +285,13 @@ export const settingsSlice = createSlice({
     resetShortcuts(state) {
       state.shortcuts = DEFAULT_SHORTCUTS
     },
+    /**
+     * Called after hydration to merge persisted shortcuts with defaults.
+     * Ensures new shortcuts from code updates are available.
+     */
+    hydrateShortcuts(state) {
+      state.shortcuts = migrateShortcuts(state.shortcuts)
+    },
   },
 })
 
@@ -122,4 +301,5 @@ export const {
   setDefaultViewMode,
   updateShortcut,
   resetShortcuts,
+  hydrateShortcuts,
 } = settingsSlice.actions

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSelector, createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 
 import type { ViewMode } from '@/lib/types'
@@ -85,3 +85,18 @@ export const {
   clearSelection,
   setCollectionViewMode,
 } = uiSlice.actions
+
+/**
+ * Select the effective view mode: per-collection override > global default.
+ * @example
+ *   const viewMode = useAppSelector(getEffectiveViewMode) // 'grid' | 'list' | ...
+ */
+export const getEffectiveViewMode = createSelector(
+  [
+    (state: { ui: UiState }) => state.ui.collectionViewModes,
+    (state: { ui: UiState }) => state.ui.selectedCollectionId,
+    (state: { ui: UiState }) => state.ui.viewMode,
+  ],
+  (collectionViewModes, selectedCollectionId, viewMode) =>
+    collectionViewModes[selectedCollectionId] ?? viewMode,
+)


### PR DESCRIPTION
## Summary

- Wire 15 modifier-key shortcuts via global `useKeyboardShortcuts` hook (Cmd+K, Cmd+N, Cmd+Shift+N, Cmd+1-4, Cmd+comma, Cmd+A, Cmd+Shift+K, Cmd+Shift+T, etc.)
- Create settings dialog with General (theme, default view) and Keyboard Shortcuts (read-only table) tabs
- Fix hydration timing bug: `hydrateShortcuts()` now runs inside `storageApi.onFinishHydration()` so localStorage rehydration doesn't overwrite merged shortcuts
- Remove hardcoded `useGlobalSearchShortcut` from `global-search-command.tsx`
- Add text-input hijacking guard (`NATIVE_TEXT_SHORTCUTS` set) so Cmd+A/Cmd+F/Cmd+Backspace work normally in inputs

### Files Changed

| Action | File | What |
|--------|------|------|
| Modified | `src/store/slices/settingsSlice.ts` | 20 shortcuts, `ShortcutActionId` type, `SHORTCUT_DEFINITIONS` |
| Modified | `src/store/index.ts` | Hydration timing fix |
| Modified | `src/components/main-app.tsx` | Wired 14 shortcut handlers |
| Modified | `src/components/raindrop/main-content.tsx` | `viewMode` prop, `data-testid` attrs |
| Modified | `src/components/raindrop/global-search-command.tsx` | Removed hardcoded Cmd+K handler |
| Modified | `src/store/slices/uiSlice.ts` | `getEffectiveViewMode` selector |
| Created | `src/lib/shortcut-utils.ts` | `matchesBinding`, `isEditableTarget`, `formatShortcut`, `findConflict` |
| Created | `src/hooks/useKeyboardShortcuts.ts` | Global keydown hook |
| Created | `src/components/raindrop/settings-dialog.tsx` | Settings dialog component |
| Created | `src/lib/shortcut-utils.test.ts` | 21 unit tests |
| Created | `src/hooks/useKeyboardShortcuts.test.ts` | 7 unit tests |
| Created | `e2e/specs/keyboard.spec.ts` | 9 E2E tests |

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 112/112 pass (28 new)
- [x] `pnpm build` — success
- [x] `pnpm knip` — clean
- [x] Keyboard E2E (`e2e/specs/keyboard.spec.ts`) — 9/9 pass
- [x] Full E2E suite — 37 pass, 11 pre-existing failures (checkbox/bulk/search, not from this PR)

Closes #18, closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * キーボードショートカットシステムを追加しました。複数のコマンド（検索パレットの開閉、ブックマーク追加、ビューモードの切り替え、設定画面を開くなど）をキーボードで実行できます。
  * 設定ダイアログを追加しました。テーマ設定、デフォルトビューモード、キーボードショートカットリファレンスを表示・管理できます。
  * ビューモード（グリッド/リスト）の設定を保持するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->